### PR TITLE
Shared blob storage between cache and audit log

### DIFF
--- a/docs/contribute/changelogs/unreleased.rst
+++ b/docs/contribute/changelogs/unreleased.rst
@@ -1,11 +1,33 @@
 Added
 :::::
 
-* Redis support for blob storage.
+* Cache: the hishel-based cache implementation now shares the blob storage with the rest of the application, to avoid
+  duplicate work and storage.
+* DX: when out of development environment, a ``start`` command stub is available so that the unadvised user does not
+  wonder where it went.
+* Monitoring: monitoring of background worker tasks pressure.
+* Storage: redis support for blob storage.
+* Storage: audit log will now react to background worker tasks pressure by disabling storage partially or entirely based
+  on the pressure amount: >10 disables content blob storage, >100 disables header blob storage, > 1000 disables message
+  storage and > 10000 disables all storage for the transaction.
+* Storage: added a ``NullBlobStorage`` implementation for testing purposes (or to disable blob storage easily).
 
 Changed
 :::::::
 
-* Blob storage is now separated from the main storage, to allow different underlying implementations.
-* Application ``harp_apps.sqlalchemy_storage`` was renamed to ``harp_apps.storage``, to reflect the fact that
+* Logging: reverted the exception formatter to plain_traceback, as it's the usual default python formatter. It works
+  better with external tools and is more readable because of the reduced verbosity.
+* Logging: all loggers have now the WARNING default level.
+* Monitoring: normalized, enhanced and complemented prometheus observability.
+* Storage: blob storage is now separated from the main storage, to allow different underlying implementations.
+* Storage: application ``harp_apps.sqlalchemy_storage`` was renamed to ``harp_apps.storage``, to reflect the fact that
   ``sqlalchemy`` is an implementation detail, and that it now handles more than just sql or sqlalchemy-based storage.
+* Storage: SQL blob storage now keeps a LRU cache of known blobs to avoid querying the database if the answer can be closer.
+* Storage: background worker queue for storage is now separated from the storage implementation.
+* Storage: test fixture ``storage`` has been renamed to ``sql_storage`` for expliciteness and less linter conflicts.
+
+Fixed
+:::::
+
+* Proxy: some errors happening when the server unexpectedly closes the connection although the client is waiting for
+  data are now caught and logged like other network/system related errors.

--- a/docs/reference/apps/harp_apps.http_client.contrib.hishel.adapters.rst
+++ b/docs/reference/apps/harp_apps.http_client.contrib.hishel.adapters.rst
@@ -1,0 +1,7 @@
+harp_apps.http_client.contrib.hishel.adapters
+=============================================
+
+.. automodule:: harp_apps.http_client.contrib.hishel.adapters
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/reference/apps/harp_apps.http_client.contrib.hishel.rst
+++ b/docs/reference/apps/harp_apps.http_client.contrib.hishel.rst
@@ -1,0 +1,17 @@
+harp_apps.http_client.contrib.hishel
+====================================
+
+.. automodule:: harp_apps.http_client.contrib.hishel
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+    :maxdepth: 1
+
+    harp_apps.http_client.contrib.hishel.adapters
+    harp_apps.http_client.contrib.hishel.storages
+    harp_apps.http_client.contrib.hishel.utils

--- a/docs/reference/apps/harp_apps.http_client.contrib.hishel.storages.rst
+++ b/docs/reference/apps/harp_apps.http_client.contrib.hishel.storages.rst
@@ -1,0 +1,7 @@
+harp_apps.http_client.contrib.hishel.storages
+=============================================
+
+.. automodule:: harp_apps.http_client.contrib.hishel.storages
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/reference/apps/harp_apps.http_client.contrib.hishel.utils.rst
+++ b/docs/reference/apps/harp_apps.http_client.contrib.hishel.utils.rst
@@ -1,0 +1,7 @@
+harp_apps.http_client.contrib.hishel.utils
+==========================================
+
+.. automodule:: harp_apps.http_client.contrib.hishel.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/reference/apps/harp_apps.http_client.contrib.rst
+++ b/docs/reference/apps/harp_apps.http_client.contrib.rst
@@ -1,0 +1,15 @@
+harp_apps.http_client.contrib
+=============================
+
+.. automodule:: harp_apps.http_client.contrib
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+    :maxdepth: 1
+
+    harp_apps.http_client.contrib.hishel

--- a/docs/reference/apps/harp_apps.http_client.rst
+++ b/docs/reference/apps/harp_apps.http_client.rst
@@ -13,4 +13,5 @@ Submodules
     :maxdepth: 1
 
     harp_apps.http_client.client
+    harp_apps.http_client.contrib
     harp_apps.http_client.settings

--- a/docs/reference/apps/harp_apps.storage.rst
+++ b/docs/reference/apps/harp_apps.storage.rst
@@ -21,3 +21,4 @@ Submodules
     harp_apps.storage.settings
     harp_apps.storage.types
     harp_apps.storage.utils
+    harp_apps.storage.worker

--- a/docs/reference/apps/harp_apps.storage.services.blob_storages.base.rst
+++ b/docs/reference/apps/harp_apps.storage.services.blob_storages.base.rst
@@ -1,7 +1,0 @@
-harp_apps.storage.services.blob_storages.base
-=============================================
-
-.. automodule:: harp_apps.storage.services.blob_storages.base
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/reference/apps/harp_apps.storage.services.blob_storages.null.rst
+++ b/docs/reference/apps/harp_apps.storage.services.blob_storages.null.rst
@@ -1,0 +1,7 @@
+harp_apps.storage.services.blob_storages.null
+=============================================
+
+.. automodule:: harp_apps.storage.services.blob_storages.null
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/reference/apps/harp_apps.storage.services.blob_storages.rst
+++ b/docs/reference/apps/harp_apps.storage.services.blob_storages.rst
@@ -12,6 +12,6 @@ Submodules
 .. toctree::
     :maxdepth: 1
 
-    harp_apps.storage.services.blob_storages.base
+    harp_apps.storage.services.blob_storages.null
     harp_apps.storage.services.blob_storages.redis
     harp_apps.storage.services.blob_storages.sql

--- a/docs/reference/apps/harp_apps.storage.worker.rst
+++ b/docs/reference/apps/harp_apps.storage.worker.rst
@@ -1,0 +1,7 @@
+harp_apps.storage.worker
+========================
+
+.. automodule:: harp_apps.storage.worker
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/reference/core/harp.utils.performances.rst
+++ b/docs/reference/core/harp.utils.performances.rst
@@ -1,0 +1,7 @@
+harp.utils.performances
+=======================
+
+.. automodule:: harp.utils.performances
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/reference/core/harp.utils.rst
+++ b/docs/reference/core/harp.utils.rst
@@ -23,6 +23,7 @@ Submodules
     harp.utils.identifiers
     harp.utils.json
     harp.utils.network
+    harp.utils.performances
     harp.utils.processes
     harp.utils.services
     harp.utils.tpdex

--- a/harp/_logging.py
+++ b/harp/_logging.py
@@ -36,13 +36,16 @@ LOGGING_FORMATTERS = {
     },
     "plain": {
         "()": structlog.stdlib.ProcessorFormatter,
-        "processor": structlog.dev.ConsoleRenderer(exception_formatter=structlog.dev.plain_traceback, colors=False),
+        "processor": structlog.dev.ConsoleRenderer(
+            exception_formatter=structlog.dev.plain_traceback,
+            colors=False,
+        ),
         "foreign_pre_chain": shared_processors,
     },
     "pretty": {
         "()": structlog.stdlib.ProcessorFormatter,
         "processor": structlog.dev.ConsoleRenderer(
-            exception_formatter=structlog.dev.RichTracebackFormatter(**_exc_formatter_options)
+            exception_formatter=structlog.dev.plain_traceback,
         ),
         "foreign_pre_chain": shared_processors,
     },
@@ -73,14 +76,14 @@ logging_config = {
         "level": logging.INFO,
     },
     "loggers": {
-        "harp": {"level": os.environ.get("LOGGING_HARP", "INFO")},
-        "harp_apps": {"level": os.environ.get("LOGGING_HARP", "INFO")},
-        "harp_apps.proxy": {"level": os.environ.get("LOGGING_HARP_PROXY", "INFO")},
+        "harp": {"level": os.environ.get("LOGGING_HARP", "WARNING")},
+        "harp_apps": {"level": os.environ.get("LOGGING_HARP", "WARNING")},
+        "harp_apps.proxy": {"level": os.environ.get("LOGGING_HARP_PROXY", "WARNING")},
         "harp.event_dispatcher": {"level": os.environ.get("LOGGING_HARP_EVENTS", "WARNING")},
         "httpcore": {"level": os.environ.get("LOGGING_HTTP", "WARNING")},  # todo wrap in structlog
         "httpx": {"level": os.environ.get("LOGGING_HTTP", "WARNING")},  # todo wrap in structlog
         "hypercorn.access": {"level": os.environ.get("LOGGING_HYPERCORN_ACCESS", "WARNING")},
-        "hypercorn.error": {"level": os.environ.get("LOGGING_HYPERCORN_ERROR", "INFO")},
+        "hypercorn.error": {"level": os.environ.get("LOGGING_HYPERCORN_ERROR", "WARNING")},
         "sqlalchemy.engine": {"level": os.environ.get("LOGGING_SQLALCHEMY", "WARNING")},
     },
 }

--- a/harp/commandline/__init__.py
+++ b/harp/commandline/__init__.py
@@ -39,7 +39,7 @@ well for now.
 
 from harp.commandline.server import server
 from harp.settings import HARP_ENV
-from harp.utils.commandline import check_packages, click
+from harp.utils.commandline import check_packages, click, code
 
 __title__ = "Command Line"
 
@@ -72,11 +72,18 @@ if IS_DEVELOPMENT_ENVIRONMENT:
     entrypoint.add_command(install_dev)
 else:
 
-    @entrypoint.add_command
+    @click.command(
+        short_help="Starts the local development environment.",
+        help=f"""Starts the local development environment, using honcho to spawn a configurable set of processes that you
+        can adapt to your needs. By default, it will starts the `dashboard` (frontend dev server) and `server` (python
+        server) processes. For live instances, you'll prefer {code('harp server')}.""",
+    )
     def start(*args, **kwargs):
         raise NotImplementedError(
             "This command is not available in production environment, please install the dev extra if you need it."
         )
+
+    entrypoint.add_command(start)
 
 
 if check_packages("alembic"):

--- a/harp/commandline/__init__.py
+++ b/harp/commandline/__init__.py
@@ -70,6 +70,14 @@ if IS_DEVELOPMENT_ENVIRONMENT:
     from harp.commandline.install import install_dev
 
     entrypoint.add_command(install_dev)
+else:
+
+    @entrypoint.add_command
+    def start(*args, **kwargs):
+        raise NotImplementedError(
+            "This command is not available in production environment, please install the dev extra if you need it."
+        )
+
 
 if check_packages("alembic"):
     from harp.commandline.migrations import create_migration, feature, history, migrate, reset

--- a/harp/commandline/server.py
+++ b/harp/commandline/server.py
@@ -3,6 +3,7 @@ from typing import cast
 from click import BaseCommand
 
 from harp.commandline.options.server import CommonServerOptions, add_harp_server_click_options
+from harp.settings import USE_PROMETHEUS
 from harp.utils.commandline import click
 
 
@@ -13,6 +14,13 @@ from harp.utils.commandline import click
 )
 @add_harp_server_click_options
 def server(**kwargs):
+    _info = None
+    if USE_PROMETHEUS:
+        from prometheus_client import Enum
+
+        _info = Enum("harp", "HARP status information.", states=["setup", "up", "teardown", "down"])
+        _info.state("setup")
+
     options = CommonServerOptions(**kwargs)
 
     from harp import Config, run
@@ -21,7 +29,14 @@ def server(**kwargs):
     config.add_defaults()
     config.read_env(options)
 
-    return run(config)
+    if _info:
+        _info.state("up")
+
+    try:
+        return run(config)
+    finally:
+        if _info:
+            _info.state("down")
 
 
 server = cast(BaseCommand, server)

--- a/harp/config/settings/base.py
+++ b/harp/config/settings/base.py
@@ -39,9 +39,6 @@ def asdict(obj, /, *, secure=True):
 
 @settings_dataclass
 class BaseSetting:
-    def to_dict(self, /, *, secure=True):
-        return asdict(self, secure=secure)
-
     def __post_init__(self):
         for _name, _hint in self.__annotations__.items():
             try:

--- a/harp/models/transactions.py
+++ b/harp/models/transactions.py
@@ -39,9 +39,12 @@ class Transaction(Entity):
     # Extra attributes
     extras: dict = dataclasses.field(default_factory=dict)
 
+    # Markers, used for transaction management (e.g. skip storage on high pressure)
+    markers: set = dataclasses.field(default_factory=set)
+
     def as_storable_dict(self, /, *, with_messages=False, with_tags=False):
         """Create a dict that can be passed to a storage creation method."""
-        data = dataclasses.asdict(self)
+        data = self._asdict()
 
         if not with_messages:
             data.pop("messages", None)
@@ -57,3 +60,8 @@ class Transaction(Entity):
         data["x_status_class"] = extras.get("status_class")
 
         return data
+
+    def _asdict(self, /, *, secure=True):
+        result = dataclasses.asdict(self)
+        del result["markers"]
+        return result

--- a/harp/tests/test_settings.py
+++ b/harp/tests/test_settings.py
@@ -1,13 +1,14 @@
 import os
 from tempfile import NamedTemporaryFile
 
+from harp.config import asdict
 from harp.config.settings import DisabledSettings, FromFileSetting
 
 
 def test_from_file_setting_not_existing():
     filename = "/this/is/very/unlikely/to/exist"
     setting = FromFileSetting(from_file=filename)
-    assert setting.to_dict() == {"from_file": filename}
+    assert asdict(setting) == {"from_file": filename}
     assert not setting.exists()
 
 
@@ -16,7 +17,7 @@ def test_from_file_setting_existing():
         with NamedTemporaryFile("w+", delete=False) as tmp_file:
             tmp_file.write("test")
             setting = FromFileSetting(from_file=tmp_file.name)
-            assert setting.to_dict() == {"from_file": tmp_file.name}
+            assert asdict(setting) == {"from_file": tmp_file.name}
             assert setting.exists()
 
         with setting.open() as f:
@@ -28,5 +29,5 @@ def test_from_file_setting_existing():
 
 def test_disabled_settings():
     setting = DisabledSettings()
-    assert setting.to_dict() == {"enabled": False}
+    assert asdict(setting) == {"enabled": False}
     assert repr(setting) == "disabled"

--- a/harp/utils/background.py
+++ b/harp/utils/background.py
@@ -2,18 +2,32 @@ import asyncio
 from inspect import iscoroutinefunction
 
 from harp import get_logger
+from harp.settings import USE_PROMETHEUS
 
 logger = get_logger(__name__)
+
+
+AsyncWorkerQueueBacklog = None
+if USE_PROMETHEUS:
+    from prometheus_client import Gauge
+
+    AsyncWorkerQueueBacklog = Gauge(
+        "async_worker_queue_backlog", "Number of items in the async worker queue.", ["queue_id"]
+    )
 
 
 class AsyncWorkerQueue:
     def __init__(self):
         self._queue = asyncio.Queue()
+        self.cleanup()
         self._task = asyncio.create_task(self())
         self._running = True
 
     async def __call__(self):
         while True:
+            if self._last_cleanup_at < asyncio.get_event_loop().time() - 5:
+                self.cleanup()
+
             try:
                 item, ignore_errors = await self._queue.get()
             except RuntimeError:
@@ -26,6 +40,13 @@ class AsyncWorkerQueue:
                     logger.exception(f"Error while executing queued task: {e}")
             finally:
                 self._queue.task_done()
+
+    def cleanup(self):
+        self._last_cleanup_at = asyncio.get_event_loop().time()
+        self._pressure = self._queue.qsize()
+        if AsyncWorkerQueueBacklog:
+            # prom ignore 0 values so we set the minimum as 1
+            AsyncWorkerQueueBacklog.labels(id(self)).set(max(self._pressure, 1))
 
     async def push(self, item, /, *, ignore_errors=False):
         if not self._running:

--- a/harp/utils/performances.py
+++ b/harp/utils/performances.py
@@ -1,0 +1,23 @@
+from contextlib import contextmanager
+
+from harp.settings import USE_PROMETHEUS
+
+if USE_PROMETHEUS:
+    from prometheus_client import Histogram
+
+    _collectors = {}
+
+    @contextmanager
+    def performances_observer(name, /, *, labels=None):
+        labels = labels or {}
+        if name not in _collectors:
+            _collectors[name] = Histogram(name, f"{name.title()} duration.", list(labels.keys()))
+
+        with _collectors[name].labels(*labels.values()).time():
+            yield
+
+else:
+
+    @contextmanager
+    def performances_observer(name, /, *, labels=None):
+        yield

--- a/harp_apps/dashboard/frontend/src/Models/Schemas/Transaction.json
+++ b/harp_apps/dashboard/frontend/src/Models/Schemas/Transaction.json
@@ -38,9 +38,14 @@
     "extras": {
       "type": "object",
       "default": {}
+    },
+    "markers": {
+      "type": "array",
+      "uniqueItems": true,
+      "default": []
     }
   },
-  "description": "Transaction(*, id: str = None, type: str, endpoint: str = None, started_at: datetime.datetime, finished_at: datetime.datetime = None, elapsed: float = None, tpdex: int = None, messages: List[harp.models.messages.Message] = None, tags: dict = <factory>, extras: dict = <factory>)",
+  "description": "Transaction(*, id: str = None, type: str, endpoint: str = None, started_at: datetime.datetime, finished_at: datetime.datetime = None, elapsed: float = None, tpdex: int = None, messages: List[harp.models.messages.Message] = None, tags: dict = <factory>, extras: dict = <factory>, markers: set = <factory>)",
   "$schema": "http://json-schema.org/draft-06/schema#",
   "definitions": {
     "Message": {

--- a/harp_apps/dashboard/frontend/src/Models/Transaction.d.ts
+++ b/harp_apps/dashboard/frontend/src/Models/Transaction.d.ts
@@ -6,7 +6,7 @@
  */
 
 /**
- * Transaction(*, id: str = None, type: str, endpoint: str = None, started_at: datetime.datetime, finished_at: datetime.datetime = None, elapsed: float = None, tpdex: int = None, messages: List[harp.models.messages.Message] = None, tags: dict = <factory>, extras: dict = <factory>)
+ * Transaction(*, id: str = None, type: str, endpoint: str = None, started_at: datetime.datetime, finished_at: datetime.datetime = None, elapsed: float = None, tpdex: int = None, messages: List[harp.models.messages.Message] = None, tags: dict = <factory>, extras: dict = <factory>, markers: set = <factory>)
  */
 export interface Transaction {
   id?: string
@@ -23,6 +23,7 @@ export interface Transaction {
   extras?: {
     [k: string]: unknown
   }
+  markers?: unknown[]
   [k: string]: unknown
 }
 /**

--- a/harp_apps/dashboard/tests/test_controllers_overview.py
+++ b/harp_apps/dashboard/tests/test_controllers_overview.py
@@ -16,8 +16,8 @@ from harp_apps.storage.utils.testing.mixins import StorageTestFixtureMixin
 
 class OverviewControllerTestFixtureMixin:
     @pytest.fixture
-    def controller(self, storage):
-        return OverviewController(storage=storage, handle_errors=False)
+    def controller(self, sql_storage):
+        return OverviewController(storage=sql_storage, handle_errors=False)
 
 
 class _Any24IntegerValues(object):
@@ -58,12 +58,12 @@ class TestOverviewController(OverviewControllerTestFixtureMixin, StorageTestFixt
 
     @parametrize_with_now
     async def test_get_summary_data_with_a_few_transactions(
-        self, controller: OverviewController, storage: SqlStorage, now
+        self, controller: OverviewController, sql_storage: SqlStorage, now
     ):
         with freezegun.freeze_time(now):
-            await self.create_transaction(storage)
-            await self.create_transaction(storage)
-            await self.create_transaction(storage)
+            await self.create_transaction(sql_storage)
+            await self.create_transaction(sql_storage)
+            await self.create_transaction(sql_storage)
         request = Mock(spec=HttpRequest, query=MultiDict())
         with freezegun.freeze_time(now):
             response = await controller.get_summary_data(request)
@@ -81,12 +81,12 @@ class TestOverviewControllerThroughASGI(
 ):
     @parametrize_with_now
     async def test_get_summary_data_with_a_few_transactions_using_asgi(
-        self, client: ASGICommunicator, storage: SqlStorage, now
+        self, client: ASGICommunicator, sql_storage: SqlStorage, now
     ):
         with freezegun.freeze_time(now):
-            await self.create_transaction(storage)
-            await self.create_transaction(storage)
-            await self.create_transaction(storage)
+            await self.create_transaction(sql_storage)
+            await self.create_transaction(sql_storage)
+            await self.create_transaction(sql_storage)
 
             response = await client.http_get("/api/overview/summary")
 

--- a/harp_apps/dashboard/tests/test_controllers_system.py
+++ b/harp_apps/dashboard/tests/test_controllers_system.py
@@ -14,7 +14,7 @@ from ..controllers import SystemController
 
 class SystemControllerTestFixtureMixin:
     @pytest.fixture
-    def controller(self, request, storage, blob_storage):
+    def controller(self, request, sql_storage, blob_storage):
         # retrieve settings overrides
         raw_settings = deepcopy(request.param)
         raw_settings.setdefault("storage", {})
@@ -22,7 +22,7 @@ class SystemControllerTestFixtureMixin:
         raw_settings["storage"]["blobs"].setdefault("type", blob_storage.type)
         config = Config(raw_settings)
         settings = config.validate()
-        return SystemController(storage=storage, settings=settings, handle_errors=False)
+        return SystemController(storage=sql_storage, settings=settings, handle_errors=False)
 
 
 def parametrize_with_settings(*args):

--- a/harp_apps/dashboard/tests/test_controllers_transactions.py
+++ b/harp_apps/dashboard/tests/test_controllers_transactions.py
@@ -15,8 +15,8 @@ from ..controllers import TransactionsController
 
 class TransactionsControllerTestFixtureMixin:
     @pytest.fixture
-    def controller(self, storage):
-        return TransactionsController(storage=storage, handle_errors=False)
+    def controller(self, sql_storage):
+        return TransactionsController(storage=sql_storage, handle_errors=False)
 
 
 class TestTransactionsController(TransactionsControllerTestFixtureMixin, StorageTestFixtureMixin):

--- a/harp_apps/dashboard/tests/test_settings.py
+++ b/harp_apps/dashboard/tests/test_settings.py
@@ -1,5 +1,6 @@
 import pytest
 
+from harp.config import asdict
 from harp.errors import ConfigurationError
 
 from ..settings import DashboardAuthSetting, DashboardSettings
@@ -20,11 +21,12 @@ def test_invalid_auth():
 
 
 def test_basic_auth():
-    assert DashboardAuthSetting(
+    settings = DashboardAuthSetting(
         type="basic",
         algorithm="plain",
         users={"foo": "bar"},
-    ).to_dict() == {
+    )
+    assert asdict(settings) == {
         "type": "basic",
         "algorithm": "plain",
         "users": {"foo": "bar"},

--- a/harp_apps/http_client/__app__.py
+++ b/harp_apps/http_client/__app__.py
@@ -4,7 +4,7 @@ from harp import get_logger
 from harp.config import Application
 from harp.config.events import FactoryBindEvent
 
-from .client import AsyncHttpClient
+from .client import AsyncClientFactory
 from .settings import HttpClientSettings
 
 logger = get_logger(__name__)
@@ -15,4 +15,4 @@ class HttpClientApplication(Application):
     settings_type = HttpClientSettings
 
     async def on_bind(self, event: FactoryBindEvent):
-        event.container.add_singleton(AsyncClient, AsyncHttpClient)
+        event.container.add_singleton(AsyncClient, AsyncClientFactory)

--- a/harp_apps/http_client/contrib/hishel/adapters.py
+++ b/harp_apps/http_client/contrib/hishel/adapters.py
@@ -1,0 +1,175 @@
+import typing as tp
+from datetime import datetime
+
+import yaml
+from hishel._async._storages import StoredResponse
+from hishel._serializers import KNOWN_REQUEST_EXTENSIONS, KNOWN_RESPONSE_EXTENSIONS, Metadata
+from hishel._utils import normalized_url
+from httpcore import Request, Response
+
+from harp.models import Blob
+from harp_apps.http_client.contrib.hishel.utils import (
+    prepare_headers_for_deserialization,
+    prepare_headers_for_serialization,
+)
+from harp_apps.storage.types import IBlobStorage
+
+
+class SerializedRequest(tp.TypedDict):
+    method: str
+    url: str
+    headers: str
+    varying: dict[str, str]
+    extensions: dict[str, str]
+
+
+class SerializedResponse(tp.TypedDict):
+    status: int
+    headers: str
+    varying: dict[str, str]
+    body: str
+    extensions: dict[str, str]
+
+
+def _ensure_datestring(date: datetime | str):
+    if isinstance(date, datetime):
+        date = date.strftime("%a, %d %b %Y %H:%M:%S GMT")
+    return date
+
+
+class AsyncStorageAdapter:
+    def __init__(self, storage: IBlobStorage):
+        self.storage = storage
+
+    async def store(self, key, /, *, response: Response, request: Request, metadata: Metadata) -> Blob:
+        serialized_request = await self._serialize_request(request)
+        serialized_response = await self._serialize_response(response)
+
+        return await self._store_cache_meta(
+            key,
+            metadata=metadata,
+            request=serialized_request,
+            response=serialized_response,
+        )
+
+    async def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
+        # todo remove expired cache ?
+
+        cached = await self.storage.get(key)
+        if not cached:
+            return None
+
+        _metadata, _request, _response = await self._decode(cached)
+
+        response = await self._unserialize_response(_response)
+        request = await self._unserialize_request(_request)
+
+        return (
+            response,
+            request,
+            Metadata(
+                cache_key=_metadata["cache_key"],
+                created_at=datetime.strptime(_metadata["created_at"], "%a, %d %b %Y %H:%M:%S GMT"),
+                number_of_uses=_metadata["number_of_uses"],
+            ),
+        )
+
+    async def update_metadata_or_save(
+        self, key: str, /, *, response: Response, request: Request, metadata: Metadata
+    ) -> Blob:
+        cached = await self.storage.get(key)
+        if not cached:
+            return await self.store(key, response=response, request=request, metadata=metadata)
+
+        old_metadata, request_data, response_data = await self._decode(cached)
+        await self._store_cache_meta(key, request=request_data, response=response_data, metadata=metadata)
+
+    async def _decode(self, cached):
+        cached = yaml.safe_load(cached.data.decode())
+        request_data, response_data, raw_metadata = cached["request"], cached["response"], cached["metadata"]
+        return raw_metadata, request_data, response_data
+
+    async def _store_cache_meta(
+        self, key, /, *, metadata: Metadata, request: SerializedRequest, response: SerializedResponse
+    ):
+        # This is a special case where we don't want this to be content adressable. This is probably not very good, but
+        # with hishel's current design, it's the only decent way to make it work that we found. Maybe we want to change
+        # the key-value store in the future to be able to contain content addressable and unadressable data, even maybe
+        # namespaced/typed data (although we hack "content-type to do it, for now).
+        return await self.storage.put(
+            Blob(
+                id=key,
+                data=yaml.safe_dump(
+                    {
+                        "request": request,
+                        "response": response,
+                        "metadata": {
+                            "cache_key": metadata["cache_key"],
+                            "number_of_uses": metadata["number_of_uses"],
+                            "created_at": _ensure_datestring(metadata["created_at"]),
+                        },
+                    },
+                    sort_keys=False,
+                ).encode(),
+                content_type="cache/meta",
+            )
+        )
+
+    async def _serialize_request(self, request: Request) -> SerializedRequest:
+        headers, varying_headers, metadata = prepare_headers_for_serialization(request.headers)
+        headers = await self.storage.put(Blob.from_data(headers, content_type="http/headers"))
+        return {
+            "method": request.method.decode("ascii"),
+            "url": normalized_url(request.url),
+            "headers": headers.id,
+            "varying": varying_headers,
+            "extensions": {key: value for key, value in request.extensions.items() if key in KNOWN_REQUEST_EXTENSIONS},
+        }
+
+    async def _unserialize_request(self, data: SerializedRequest) -> Request:
+        headers = await self.storage.get(data["headers"])
+
+        return Request(
+            method=data["method"],
+            url=data["url"],
+            headers=prepare_headers_for_deserialization(headers.data, varying=data.get("varying") or {}),
+            extensions=data.get("extensions") or {},
+        )
+
+    async def _serialize_response(self, response: Response) -> SerializedResponse:
+        headers, varying_headers, metadata = prepare_headers_for_serialization(
+            response.headers,
+            varying=(
+                b"date",
+                b"content-length",
+            ),
+        )
+        headers = await self.storage.put(Blob.from_data(headers, content_type="http/headers"))
+        body = await self.storage.put(
+            Blob.from_data(
+                response.content,
+                content_type=metadata.get("content-type") or "application/octet-stream",
+            )
+        )
+        return {
+            "status": response.status,
+            "headers": headers.id,
+            "varying": varying_headers,
+            "body": body.id,
+            "extensions": {
+                key: value.decode("ascii")
+                for key, value in response.extensions.items()
+                if key in KNOWN_RESPONSE_EXTENSIONS
+            },
+        }
+
+    async def _unserialize_response(self, data: SerializedResponse) -> Response:
+        headers = await self.storage.get(data["headers"])
+        body = await self.storage.get(data["body"])
+
+        return Response(
+            status=data["status"],
+            headers=prepare_headers_for_deserialization(headers.data, varying=data.get("varying") or {}),
+            content=body.data,
+            extensions={key: value.encode() for key, value in (data.get("extensions") or {}).items()},
+        )

--- a/harp_apps/http_client/contrib/hishel/storages.py
+++ b/harp_apps/http_client/contrib/hishel/storages.py
@@ -1,0 +1,55 @@
+import time
+import typing as tp
+from datetime import datetime, timezone
+
+from hishel import AsyncBaseStorage
+from hishel._async._storages import StoredResponse
+from hishel._serializers import Metadata
+from httpcore import Request, Response
+
+from harp_apps.storage.types import IBlobStorage
+
+from .adapters import AsyncStorageAdapter
+
+HEADERS_ENCODING = "iso-8859-1"
+
+
+class AsyncStorage(AsyncBaseStorage):
+    def __init__(
+        self,
+        storage: IBlobStorage,
+        ttl: tp.Optional[tp.Union[int, float]] = None,
+        check_ttl_every: tp.Union[int, float] = 60,
+    ):
+        super().__init__(serializer=None, ttl=ttl)
+
+        self._check_ttl_every = check_ttl_every
+        self._last_cleaned = time.monotonic()
+        self._impl = AsyncStorageAdapter(storage)
+        self._storage = storage
+
+    async def store(self, key: str, response: Response, request: Request, metadata: Metadata | None = None) -> None:
+        # XXX this looks like the wrong place to do it, but hishel depends on this behaviour. Let's mimic the other
+        #  storages, for now.
+        metadata = metadata or Metadata(cache_key=key, created_at=datetime.now(timezone.utc), number_of_uses=0)
+
+        await self._impl.store(
+            key,
+            request=request,
+            response=response,
+            metadata=metadata,
+        )
+
+    async def update_metadata(self, key: str, response: Response, request: Request, metadata: Metadata) -> None:
+        await self._impl.update_metadata_or_save(
+            key,
+            request=request,
+            response=response,
+            metadata=metadata,
+        )
+
+    async def retrieve(self, key: str) -> tp.Optional[StoredResponse]:
+        return await self._impl.retrieve(key)
+
+    async def aclose(self) -> None:
+        return

--- a/harp_apps/http_client/contrib/hishel/utils.py
+++ b/harp_apps/http_client/contrib/hishel/utils.py
@@ -1,0 +1,33 @@
+from harp.utils.bytes import ensure_bytes
+
+
+def prepare_headers_for_serialization(
+    headers: list[tuple[bytes, bytes]], /, *, varying=()
+) -> tuple[bytes, dict[str, str], dict[str, str]]:
+    static_headers = []
+    varying_headers = {}
+    metadata = {}
+
+    for k, v in headers:
+        k = k.lower().strip()
+        if k in varying:
+            varying_headers[k.decode()] = v.decode()
+        else:
+            static_headers.append(b": ".join((k, v)))
+
+        if k == b"content-type":
+            metadata["content-type"] = v.decode()
+
+    return b"\n".join(static_headers), varying_headers, metadata
+
+
+def _parse_header(header: bytes) -> tuple[bytes, bytes]:
+    splitted = header.split(b": ", 1)
+    return (splitted[0], splitted[1])
+
+
+def prepare_headers_for_deserialization(headers: bytes, /, *, varying: dict) -> list[tuple[bytes, bytes]]:
+    return [
+        *(_parse_header(header) for header in headers.split(b"\n")),
+        *((ensure_bytes(k), ensure_bytes(v)) for k, v in varying.items()),
+    ]

--- a/harp_apps/http_client/settings.py
+++ b/harp_apps/http_client/settings.py
@@ -23,6 +23,8 @@ class CacheSettings(DisableableBaseSettings):
         cacheable_status_codes=list(HEURISTICALLY_CACHEABLE_STATUS_CODES),
     )
     storage: Definition["AsyncBaseStorage"] = Lazy(None)
+    ttl: Optional[float] = None
+    check_ttl_every: float = 60
 
 
 @settings_dataclass

--- a/harp_apps/http_client/tests/test_settings.py
+++ b/harp_apps/http_client/tests/test_settings.py
@@ -2,8 +2,9 @@ import hishel
 import httpx
 
 from harp.config import DisabledSettings
-from harp_apps.http_client.client import AsyncHttpClient
+from harp_apps.http_client.client import AsyncClientFactory
 from harp_apps.http_client.settings import CacheSettings, HttpClientSettings
+from harp_apps.storage.services.blob_storages.null import NullBlobStorage
 
 
 class TestHttpClientSettings:
@@ -13,7 +14,7 @@ class TestHttpClientSettings:
         assert settings.cache.enabled is False
         assert isinstance(settings.cache, DisabledSettings)
 
-        client = AsyncHttpClient(settings)
+        client = AsyncClientFactory(settings, NullBlobStorage())
         assert isinstance(client._transport, httpx.AsyncHTTPTransport)
 
     def test_without_cache_with_custom_client(self):
@@ -25,7 +26,7 @@ class TestHttpClientSettings:
         assert settings.cache.enabled is False
         assert isinstance(settings.cache, DisabledSettings)
 
-        client = AsyncHttpClient(settings)
+        client = AsyncClientFactory(settings, NullBlobStorage())
         assert isinstance(client._transport, httpx._client.BaseClient)
 
     def test_with_default_cache(self):
@@ -34,7 +35,7 @@ class TestHttpClientSettings:
         assert settings.cache.enabled is True
         assert isinstance(settings.cache, CacheSettings)
 
-        client = AsyncHttpClient(settings)
+        client = AsyncClientFactory(settings, NullBlobStorage())
         assert isinstance(client._transport, hishel.AsyncCacheTransport)
         assert client._transport._controller._allow_heuristics is False
         assert client._transport._controller._allow_stale is False
@@ -58,7 +59,7 @@ class TestHttpClientSettings:
         assert settings.cache.enabled is True
         assert isinstance(settings.cache, CacheSettings)
 
-        client = AsyncHttpClient(settings)
+        client = AsyncClientFactory(settings, NullBlobStorage())
         assert isinstance(client._transport, hishel.AsyncCacheTransport)
 
         assert isinstance(client._transport._controller, hishel.Controller)

--- a/harp_apps/janitor/tests/test_worker.py
+++ b/harp_apps/janitor/tests/test_worker.py
@@ -10,66 +10,70 @@ from harp_apps.storage.utils.testing.mixins import StorageTestFixtureMixin
 
 
 class TestJanitorWorker(StorageTestFixtureMixin):
-    async def test_delete_old_transactions(self, storage: SqlStorage, blob_storage: IBlobStorage):
-        worker = JanitorWorker(storage, blob_storage)
+    async def test_delete_old_transactions(self, sql_storage: SqlStorage, blob_storage: IBlobStorage):
+        worker = JanitorWorker(sql_storage, blob_storage)
 
-        await self.create_transaction(storage, started_at=datetime.now(UTC) - OLD_AFTER - timedelta(hours=1))
-        await self.create_transaction(storage, started_at=datetime.now(UTC) - OLD_AFTER - timedelta(minutes=1))
-        await self.create_transaction(storage, started_at=datetime.now(UTC) - OLD_AFTER + timedelta(minutes=1))
+        await self.create_transaction(sql_storage, started_at=datetime.now(UTC) - OLD_AFTER - timedelta(hours=1))
+        await self.create_transaction(sql_storage, started_at=datetime.now(UTC) - OLD_AFTER - timedelta(minutes=1))
+        await self.create_transaction(sql_storage, started_at=datetime.now(UTC) - OLD_AFTER + timedelta(minutes=1))
 
-        async with storage.session_factory() as session:
+        async with sql_storage.session_factory() as session:
             assert (await worker.compute_metrics(session))["storage.transactions"] == 3
 
         await worker.delete_old_transactions()
 
-        async with storage.session_factory() as session:
+        async with sql_storage.session_factory() as session:
             assert (await worker.compute_metrics(session))["storage.transactions"] == 1
 
-    async def test_delete_orphan_blobs(self, storage: SqlStorage, blob_storage: IBlobStorage):
+    async def test_delete_orphan_blobs(self, sql_storage: SqlStorage, blob_storage: IBlobStorage):
         if blob_storage.type == "redis":
             # explicit skip because it should be implemented later
             return pytest.skip("Redis implementation does not support cleaning up orphan blobs yet.")
 
-        worker = JanitorWorker(storage, blob_storage)
+        worker = JanitorWorker(sql_storage, blob_storage)
 
         b1 = await self.create_blob(blob_storage, "foo")
         b2 = await self.create_blob(blob_storage, "bar")
         await self.create_blob(blob_storage, "baz")
 
-        async with storage.session_factory() as session:
+        async with sql_storage.session_factory() as session:
             metrics = await worker.compute_metrics(session)
             assert metrics["storage.blobs"] == 3
             assert metrics["storage.blobs.orphans"] == 3
 
-        t = await self.create_transaction(storage)
-        await self.create_message(storage, transaction_id=t.id, kind="misc", summary="foo", headers=b1.id, body=b2.id)
+        t = await self.create_transaction(sql_storage)
+        await self.create_message(
+            sql_storage, transaction_id=t.id, kind="misc", summary="foo", headers=b1.id, body=b2.id
+        )
 
-        async with storage.session_factory() as session:
+        async with sql_storage.session_factory() as session:
             metrics = await worker.compute_metrics(session)
             assert metrics["storage.blobs"] == 3
             assert metrics["storage.blobs.orphans"] == 1
 
         await worker.delete_orphan_blobs()
 
-        async with storage.session_factory() as session:
+        async with sql_storage.session_factory() as session:
             metrics = await worker.compute_metrics(session)
             assert metrics["storage.blobs"] == 2
             assert metrics["storage.blobs.orphans"] == 0
 
-    async def test_delete_old_transactions_but_keep_flagged_ones(self, storage: SqlStorage, blob_storage: IBlobStorage):
-        worker = JanitorWorker(storage, blob_storage)
+    async def test_delete_old_transactions_but_keep_flagged_ones(
+        self, sql_storage: SqlStorage, blob_storage: IBlobStorage
+    ):
+        worker = JanitorWorker(sql_storage, blob_storage)
 
-        t1 = await self.create_transaction(storage, started_at=datetime.now(UTC) - OLD_AFTER - timedelta(hours=1))
-        await self.create_transaction(storage, started_at=datetime.now(UTC) - OLD_AFTER - timedelta(minutes=1))
-        await self.create_transaction(storage, started_at=datetime.now(UTC) - OLD_AFTER + timedelta(minutes=1))
+        t1 = await self.create_transaction(sql_storage, started_at=datetime.now(UTC) - OLD_AFTER - timedelta(hours=1))
+        await self.create_transaction(sql_storage, started_at=datetime.now(UTC) - OLD_AFTER - timedelta(minutes=1))
+        await self.create_transaction(sql_storage, started_at=datetime.now(UTC) - OLD_AFTER + timedelta(minutes=1))
 
-        user = await storage.users.find_one_by_username("anonymous")
-        await storage.flags.create({"type": 1, "user_id": user.id, "transaction_id": t1.id})
+        user = await sql_storage.users.find_one_by_username("anonymous")
+        await sql_storage.flags.create({"type": 1, "user_id": user.id, "transaction_id": t1.id})
 
-        async with storage.session_factory() as session:
+        async with sql_storage.session_factory() as session:
             assert (await worker.compute_metrics(session))["storage.transactions"] == 3
 
         await worker.delete_old_transactions()
 
-        async with storage.session_factory() as session:
+        async with sql_storage.session_factory() as session:
             assert (await worker.compute_metrics(session))["storage.transactions"] == 2

--- a/harp_apps/proxy/tests/with_storage/test_controllers_http_proxy.py
+++ b/harp_apps/proxy/tests/with_storage/test_controllers_http_proxy.py
@@ -3,15 +3,19 @@ from unittest.mock import ANY, AsyncMock, patch
 import pytest
 import respx
 from httpx import AsyncClient, Response
-from whistle import AsyncEventDispatcher
+from sqlalchemy.ext.asyncio import AsyncEngine
+from whistle import AsyncEventDispatcher, IAsyncEventDispatcher
 
+from harp.config import asdict
+from harp.http import HttpRequest, HttpResponse
 from harp.utils.bytes import ensure_bytes
 from harp.utils.testing.mixins import ControllerTestFixtureMixin
 from harp_apps.proxy.controllers import HttpProxyController
 from harp_apps.proxy.events import EVENT_TRANSACTION_STARTED
 from harp_apps.storage.services.sql import SqlStorage
-from harp_apps.storage.types import IBlobStorage
+from harp_apps.storage.types import IBlobStorage, IStorage
 from harp_apps.storage.utils.testing.mixins import StorageTestFixtureMixin
+from harp_apps.storage.worker import StorageAsyncWorkerQueue
 
 
 class DispatcherTestFixtureMixin:
@@ -34,17 +38,34 @@ class HttpProxyControllerTestFixtureMixin(ControllerTestFixtureMixin):
         will be called and you may have some headaches..."""
         return respx.get(database_url).mock(return_value=Response(status, content=ensure_bytes(content)))
 
-    def create_controller(self, url=None, *args, http_client=None, **kwargs):
+    def create_controller(self, url=None, *args, dispatcher: IAsyncEventDispatcher, http_client=None, **kwargs):
         return super().create_controller(
-            url or "http://example.com/", *args, http_client=http_client or AsyncClient(), **kwargs
+            url or "http://example.com/",
+            *args,
+            dispatcher=dispatcher,
+            http_client=http_client or AsyncClient(),
+            **kwargs,
         )
+
+    def create_worker(
+        self,
+        dispatcher: IAsyncEventDispatcher,
+        engine: AsyncEngine,
+        sql_storage: IStorage,
+        blob_storage: IBlobStorage,
+    ) -> StorageAsyncWorkerQueue:
+        worker = StorageAsyncWorkerQueue(engine, sql_storage, blob_storage)
+        worker.register_events(dispatcher)
+        return worker
 
 
 class TestHttpProxyController(HttpProxyControllerTestFixtureMixin, DispatcherTestFixtureMixin):
     @respx.mock
-    async def test_basic_get(self):
+    async def test_basic_get(self, dispatcher: IAsyncEventDispatcher):
         endpoint = self.mock_http_endpoint("http://example.com/", content="Hello.")
-        request, response = await self.call_controller(self.create_controller("http://example.com/"))
+        request, response = await self.call_controller(
+            self.create_controller("http://example.com/", dispatcher=dispatcher)
+        )
 
         # check output and side effects
         assert endpoint.called and endpoint.call_count == 1
@@ -53,7 +74,7 @@ class TestHttpProxyController(HttpProxyControllerTestFixtureMixin, DispatcherTes
         assert response.body == b"Hello."
 
     @respx.mock
-    async def test_get_with_tags(self, dispatcher: AsyncEventDispatcher):
+    async def test_get_with_tags(self, dispatcher: IAsyncEventDispatcher):
         endpoint = self.mock_http_endpoint("http://example.com/", content="Hello.")
 
         # register a mock handler to inspect the actually created transaction
@@ -91,6 +112,27 @@ class TestHttpProxyControllerWithStorage(
     StorageTestFixtureMixin,
     DispatcherTestFixtureMixin,
 ):
+    async def call_controller(
+        self,
+        controller=None,
+        /,
+        *,
+        dispatcher=None,
+        engine=None,
+        sql_storage=None,
+        blob_storage=None,
+        body=None,
+        method="GET",
+        headers=None,
+    ) -> tuple[HttpRequest, HttpResponse]:
+        dispatcher: IAsyncEventDispatcher = dispatcher or AsyncEventDispatcher()
+        controller = controller or self.create_controller(dispatcher=dispatcher)
+        worker = self.create_worker(dispatcher, engine, sql_storage, blob_storage)
+        try:
+            return await super().call_controller(controller, body=body, method=method, headers=headers)
+        finally:
+            await worker.wait_until_empty()
+
     async def _find_one_transaction_with_messages_from_storage(self, storage):
         # get transaction, request and response
         transactions = await storage.get_transaction_list(username="anonymous", with_messages=True)
@@ -99,17 +141,14 @@ class TestHttpProxyControllerWithStorage(
         return transaction, transaction.messages[0], transaction.messages[1]
 
     @respx.mock
-    async def test_basic_get(self, storage: SqlStorage, blob_storage: IBlobStorage):
+    async def test_basic_get(self, sql_storage: SqlStorage, blob_storage: IBlobStorage):
         self.mock_http_endpoint("http://example.com/", content="Hello.")
 
         # register the storage
-        await self.call_controller(self.create_controller("http://example.com/", dispatcher=storage._dispatcher))
-        await storage.wait_for_background_tasks_to_be_processed()
+        await self.call_controller(engine=sql_storage.engine, sql_storage=sql_storage, blob_storage=blob_storage)
 
-        transaction, request, response = await self._find_one_transaction_with_messages_from_storage(storage)
-
-        # transaction
-        assert transaction.to_dict(omit_none=False) == {
+        transaction, request, response = await self._find_one_transaction_with_messages_from_storage(sql_storage)
+        assert asdict(transaction) == {
             "id": ANY,
             "type": "http",
             "endpoint": None,
@@ -123,49 +162,54 @@ class TestHttpProxyControllerWithStorage(
         }
 
         # request
-        assert (await blob_storage.get(request.headers)).data == b"host: example.com\nuser-agent: test/1.0"
+        request_headers = await blob_storage.get(request.headers)
+        assert request_headers.data == b"host: example.com\nuser-agent: test/1.0"
+        assert request_headers.content_type == "http/headers"
         assert (await blob_storage.get(request.body)).data == b""
-        assert request.to_dict(omit_none=False) == {
+        assert asdict(request) == {
             "id": 1,
             "transaction_id": ANY,
             "kind": "request",
             "summary": "GET / HTTP/1.1",
-            "headers": "ecd46dd3023926417e1205b219aec4c2b9e0dab0",
+            "headers": "a11eda99171248663db8cf2ef3857f52a974ba94",
             "body": "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc",
             "created_at": ANY,
         }
 
         # response
-        assert (await blob_storage.get(response.headers)).data == b""
+        response_headers = await blob_storage.get(response.headers)
+        assert response_headers.data == b""
+        assert response_headers.content_type == "http/headers"
         assert (await blob_storage.get(response.body)).data == b"Hello."
-        assert response.to_dict(omit_none=False) == {
+        assert asdict(response) == {
             "id": 2,
             "transaction_id": ANY,
             "kind": "response",
             "summary": "HTTP/1.1 200 OK",
-            "headers": "7507b0bca78329128f61f37d09c88b8712cecd64",
+            "headers": "916ef336ce8ac9a91de41ce88c4b4bfc747b3ac9",
             "body": "6ffdd89703735cc316470566467b816446f008ce",
             "created_at": ANY,
         }
 
     @respx.mock
-    async def test_get_with_tags(self, storage: SqlStorage, blob_storage: IBlobStorage):
+    async def test_get_with_tags(self, sql_storage: SqlStorage, blob_storage: IBlobStorage):
         self.mock_http_endpoint("http://example.com/", content="Hello.")
 
         # call our controller
         await self.call_controller(
-            self.create_controller("http://example.com/", dispatcher=storage._dispatcher),
+            engine=sql_storage.engine,
+            sql_storage=sql_storage,
+            blob_storage=blob_storage,
             headers={
                 "x-harp-foo": "bar",
                 "accept": "application/json",
                 "vary": "custom",
             },
         )
-        await storage.wait_for_background_tasks_to_be_processed()
 
-        transaction, request, response = await self._find_one_transaction_with_messages_from_storage(storage)
+        transaction, request, response = await self._find_one_transaction_with_messages_from_storage(sql_storage)
 
-        assert transaction.to_dict(omit_none=False) == {
+        assert asdict(transaction) == {
             "id": ANY,
             "type": "http",
             "endpoint": None,
@@ -178,28 +222,32 @@ class TestHttpProxyControllerWithStorage(
             "extras": {"flags": [], "method": "GET", "status_class": "2xx", "cached": False, "no_cache": False},
         }
 
-        assert (await blob_storage.get(request.headers)).data == (
+        request_headers = await blob_storage.get(request.headers)
+        assert request_headers.data == (
             b"accept: application/json\nvary: custom\nhost: example.com\nuser-agent: test/1.0"
         )
+        assert request_headers.content_type == "http/headers"
         assert (await blob_storage.get(request.body)).data == b""
-        assert request.to_dict(omit_none=False) == {
+        assert asdict(request) == {
             "id": 1,
             "transaction_id": ANY,
             "kind": "request",
             "summary": "GET / HTTP/1.1",
-            "headers": "885ad9e4633a3c038f13c32e4ee48fc9221c0152",
+            "headers": "74c903b455127bd235bb06e9e84151e9535c6389",
             "body": "adc83b19e793491b1c6ea0fd8b46cd9f32e592fc",
             "created_at": ANY,
         }
 
-        assert (await blob_storage.get(response.headers)).data == b""
+        response_headers = await blob_storage.get(response.headers)
+        assert response_headers.data == b""
+        assert response_headers.content_type == "http/headers"
         assert (await blob_storage.get(response.body)).data == b"Hello."
-        assert response.to_dict(omit_none=False) == {
+        assert asdict(response) == {
             "id": 2,
             "transaction_id": ANY,
             "kind": "response",
             "summary": "HTTP/1.1 200 OK",
-            "headers": "7507b0bca78329128f61f37d09c88b8712cecd64",
+            "headers": "916ef336ce8ac9a91de41ce88c4b4bfc747b3ac9",
             "body": "6ffdd89703735cc316470566467b816446f008ce",
             "created_at": ANY,
         }

--- a/harp_apps/storage/conftest.py
+++ b/harp_apps/storage/conftest.py
@@ -3,7 +3,6 @@ from functools import partial
 import pytest
 from alembic import command
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
-from whistle import AsyncEventDispatcher
 
 from conftest import DEFAULT_STORAGE_SETTINGS
 from harp.utils.testing.databases import TEST_DATABASES
@@ -77,10 +76,9 @@ async def sql_engine(database_url, test_id) -> AsyncEngine:
 
 
 @pytest.fixture
-async def storage(sql_engine, blob_storage) -> SqlStorage:
+async def sql_storage(sql_engine, blob_storage) -> SqlStorage:
     storage = SqlStorage(
         sql_engine,
-        dispatcher=AsyncEventDispatcher(),
         blob_storage=blob_storage,
         settings=StorageSettings(**(DEFAULT_STORAGE_SETTINGS | {"url": sql_engine.url})),
     )

--- a/harp_apps/storage/services/blob_storages/base.py
+++ b/harp_apps/storage/services/blob_storages/base.py
@@ -1,7 +1,0 @@
-from abc import ABCMeta
-
-from harp_apps.storage.types import IBlobStorage
-
-
-class AbstractBlobStorage(IBlobStorage, metaclass=ABCMeta):
-    type = None

--- a/harp_apps/storage/services/blob_storages/null.py
+++ b/harp_apps/storage/services/blob_storages/null.py
@@ -1,0 +1,18 @@
+from harp.models import Blob
+from harp_apps.storage.types import IBlobStorage
+
+
+class NullBlobStorage(IBlobStorage):
+    type = "null"
+
+    async def get(self, blob_id: str):
+        return None
+
+    async def put(self, blob: Blob) -> Blob:
+        return blob
+
+    async def delete(self, blob_id: str):
+        pass
+
+    async def exists(self, blob_id: str) -> bool:
+        return False

--- a/harp_apps/storage/tests/test_models_base.py
+++ b/harp_apps/storage/tests/test_models_base.py
@@ -11,14 +11,14 @@ from harp_apps.storage.utils.testing.mixins import StorageTestFixtureMixin
 
 
 class TestModelsBase(StorageTestFixtureMixin):
-    async def test_create_using_explicit_session(self, storage: SqlStorage):
+    async def test_create_using_explicit_session(self, sql_storage: SqlStorage):
         """
         Check how instance creation works with an explicit session scope created outside the "create" call.
 
         """
-        async with storage.session_factory() as session:
+        async with sql_storage.session_factory() as session:
             # we create a transaction with our own session
-            db_transaction = await storage.transactions.create(
+            db_transaction = await sql_storage.transactions.create(
                 {
                     "id": generate_transaction_id_ksuid(),
                     "type": "http",
@@ -46,13 +46,13 @@ class TestModelsBase(StorageTestFixtureMixin):
         assert inspect(db_transaction).detached is True
         assert inspect(db_transaction).expired is False
 
-    async def test_create_using_inplicit_session(self, storage: SqlStorage):
+    async def test_create_using_inplicit_session(self, sql_storage: SqlStorage):
         """
         Check how instance creation works with an implicit session.
 
         """
         # we create a transaction without an explicit session
-        db_transaction = await storage.transactions.create(
+        db_transaction = await sql_storage.transactions.create(
             {
                 "id": generate_transaction_id_ksuid(),
                 "type": "http",

--- a/harp_apps/storage/tests/test_services_blob_storages_sql.py
+++ b/harp_apps/storage/tests/test_services_blob_storages_sql.py
@@ -12,12 +12,12 @@ async def test_basics(sql_blob_storage: SqlBlobStorage):
 
     assert _storage.type == "sql"
     assert await _storage.get("foo") is None
-    async with _storage.begin() as conn:
+    async with _storage.engine.connect() as conn:
         assert (await conn.execute(text("SELECT * FROM blobs WHERE id = 'foo'"))).fetchone() is None
 
     assert await _storage.put(blob) == blob
     assert await _storage.get("foo") == blob
-    async with _storage.begin() as conn:
+    async with _storage.engine.connect() as conn:
         assert (
             await conn.execute(
                 text("SELECT * FROM blobs WHERE id = 'foo'"),
@@ -28,5 +28,5 @@ async def test_basics(sql_blob_storage: SqlBlobStorage):
     assert await _storage.delete("foo") is None
     assert not await _storage.exists("foo")
     assert await _storage.get("foo") is None
-    async with _storage.begin() as conn:
+    async with _storage.engine.connect() as conn:
         assert (await conn.execute(text("SELECT * FROM blobs WHERE id = 'foo'"))).fetchone() is None

--- a/harp_apps/storage/tests/test_storage_tags.py
+++ b/harp_apps/storage/tests/test_storage_tags.py
@@ -3,16 +3,16 @@ from harp_apps.storage.utils.testing.mixins import StorageTestFixtureMixin
 
 
 class TestStorageTags(StorageTestFixtureMixin):
-    async def test_get_transaction_list_with_tags(self, storage: SqlStorage):
-        t1 = await self.create_transaction(storage)
+    async def test_get_transaction_list_with_tags(self, sql_storage: SqlStorage):
+        t1 = await self.create_transaction(sql_storage)
 
         tags = {"version": "42", "env": "tests"}
 
         # set some tags
-        await storage.transactions.set_tags(t1, tags)
+        await sql_storage.transactions.set_tags(t1, tags)
 
         # refresh our transaction from db (test env allow us to do this)
-        t1_again = await storage.transactions.find_one_by_id(t1.id, with_tags=True)
+        t1_again = await sql_storage.transactions.find_one_by_id(t1.id, with_tags=True)
 
         # internal api returns 2 tags
         assert (len(t1_again._tag_values)) == 2

--- a/harp_apps/storage/tests/test_storage_transactions.py
+++ b/harp_apps/storage/tests/test_storage_transactions.py
@@ -3,28 +3,38 @@ from harp_apps.storage.utils.testing.mixins import StorageTestFixtureMixin
 
 
 class TestStorageTransactions(StorageTestFixtureMixin):
-    async def test_get_transaction_list_with_tags(self, storage: SqlStorage):
-        t1 = await self.create_transaction(storage, endpoint="foo")
+    async def test_get_transaction_list_with_tags(self, sql_storage: SqlStorage):
+        t1 = await self.create_transaction(sql_storage, endpoint="foo")
 
-        t2 = await self.create_transaction(storage, endpoint="bar")
+        t2 = await self.create_transaction(sql_storage, endpoint="bar")
 
-        t3 = await self.create_transaction(storage, endpoint="baz")
+        t3 = await self.create_transaction(sql_storage, endpoint="baz")
 
         # messages
-        await self.create_message(storage, transaction_id=t1.id, kind="misc", summary="bal", headers="foo", body="foo")
-        await self.create_message(storage, transaction_id=t2.id, kind="misc", summary="foo", headers="bar", body="baz")
-        await self.create_message(storage, transaction_id=t3.id, kind="misc", summary="baz", headers="baz", body="baz")
+        await self.create_message(
+            sql_storage, transaction_id=t1.id, kind="misc", summary="bal", headers="foo", body="foo"
+        )
+        await self.create_message(
+            sql_storage, transaction_id=t2.id, kind="misc", summary="foo", headers="bar", body="baz"
+        )
+        await self.create_message(
+            sql_storage, transaction_id=t3.id, kind="misc", summary="baz", headers="baz", body="baz"
+        )
 
         # assert stuff
-        transactions_bar = await storage.get_transaction_list(
+        transactions_bar = await sql_storage.get_transaction_list(
             username="anonymous", with_messages=True, text_search="bar"
         )
         assert len(transactions_bar) == 1
 
         assert transactions_bar[0].id == t2.id
 
-        transactions_fo = await storage.get_transaction_list(username="anonymous", with_messages=True, text_search="fo")
+        transactions_fo = await sql_storage.get_transaction_list(
+            username="anonymous", with_messages=True, text_search="fo"
+        )
         assert len(transactions_fo) == 2
 
-        transactions_ba = await storage.get_transaction_list(username="anonymous", with_messages=True, text_search="ba")
+        transactions_ba = await sql_storage.get_transaction_list(
+            username="anonymous", with_messages=True, text_search="ba"
+        )
         assert len(transactions_ba) == 3

--- a/harp_apps/storage/tests/test_storage_usage.py
+++ b/harp_apps/storage/tests/test_storage_usage.py
@@ -3,12 +3,12 @@ from harp_apps.storage.utils.testing.mixins import StorageTestFixtureMixin
 
 
 class TestStorageUsage(StorageTestFixtureMixin):
-    async def test_get_usage(self, storage: SqlStorage):
-        usage = await storage.get_usage()
+    async def test_get_usage(self, sql_storage: SqlStorage):
+        usage = await sql_storage.get_usage()
         assert usage == 0
 
         for i in range(3):
-            await self.create_transaction(storage)
+            await self.create_transaction(sql_storage)
 
-        usage = await storage.get_usage()
+        usage = await sql_storage.get_usage()
         assert usage == 3

--- a/harp_apps/storage/worker.py
+++ b/harp_apps/storage/worker.py
@@ -1,0 +1,116 @@
+from datetime import UTC
+from functools import partial
+from math import log10
+
+from sqlalchemy import insert, update
+from sqlalchemy.ext.asyncio import AsyncEngine
+from whistle import IAsyncEventDispatcher
+
+from harp.asgi.events import HttpMessageEvent, TransactionEvent
+from harp.http import get_serializer_for
+from harp.models import Blob
+from harp.utils.background import AsyncWorkerQueue
+from harp_apps.proxy.events import EVENT_TRANSACTION_ENDED, EVENT_TRANSACTION_MESSAGE, EVENT_TRANSACTION_STARTED
+from harp_apps.storage.models import Message as SqlMessage
+from harp_apps.storage.models import Transaction as SqlTransaction
+from harp_apps.storage.types import IBlobStorage, IStorage
+
+SKIP_STORAGE = "skip-storage"
+
+
+class StorageAsyncWorkerQueue(AsyncWorkerQueue):
+    def __init__(self, engine: AsyncEngine, storage: IStorage, blob_storage: IBlobStorage):
+        self.engine = engine
+        self.storage = storage
+        self.blob_storage = blob_storage
+        super().__init__()
+        self.seen = set()
+
+    def register_events(self, dispatcher: IAsyncEventDispatcher):
+        dispatcher.add_listener(EVENT_TRANSACTION_STARTED, self.on_transaction_started)
+        dispatcher.add_listener(EVENT_TRANSACTION_MESSAGE, self.on_transaction_message)
+        dispatcher.add_listener(EVENT_TRANSACTION_ENDED, self.on_transaction_ended)
+
+    def cleanup(self):
+        super().cleanup()
+
+    @property
+    def pressure(self):
+        if self._pressure <= 1:
+            return 0
+        return int(log10(self._pressure))
+
+    async def on_transaction_started(self, event: TransactionEvent):
+        """Event handler to store the transaction in the database."""
+
+        if self.pressure >= 4:
+            event.transaction.markers.add(SKIP_STORAGE)
+            return
+
+        # Copy fields into a dict that won't change before the task is handled
+        transaction_data = event.transaction.as_storable_dict(with_tags=True)
+
+        async def create_transaction():
+            return await self.storage.transactions.create(transaction_data)
+
+        # Schedule
+        await self.push(create_transaction)
+
+    async def on_transaction_message(self, event: HttpMessageEvent):
+        if SKIP_STORAGE in event.transaction.markers or self.pressure >= 3:
+            return
+
+        await event.message.join()
+        serializer = get_serializer_for(event.message)
+
+        message_data = {
+            "transaction_id": event.transaction.id,
+            "kind": event.message.kind,
+            "summary": serializer.summary,
+            "created_at": event.message.created_at,
+        }
+
+        # Eventually store the headers blob (later)
+        if self.pressure <= 2:
+            headers_blob = Blob.from_data(serializer.headers, content_type="http/headers")
+            await self.push(partial(self.blob_storage.put, headers_blob), ignore_errors=True)
+            message_data["headers"] = headers_blob.id
+
+        # Eventually store the content blob (later)
+        if self.pressure <= 1:
+            content_blob = Blob.from_data(serializer.body, content_type=event.message.headers.get("content-type"))
+            await self.push(partial(self.blob_storage.put, content_blob), ignore_errors=True)
+            message_data["body"] = content_blob.id
+
+        async def create_message():
+            async with self.engine.connect() as conn:
+                await conn.execute(insert(SqlMessage).values(**message_data))
+                await conn.commit()
+
+        await self.push(create_message)
+
+    async def on_transaction_ended(self, event: TransactionEvent):
+        if SKIP_STORAGE in event.transaction.markers:
+            return
+
+        transaction_id = event.transaction.id
+        transaction_data = {
+            "finished_at": event.transaction.finished_at.astimezone(UTC),
+            "elapsed": event.transaction.elapsed,
+            "tpdex": event.transaction.tpdex,
+            "x_status_class": event.transaction.extras.get("status_class"),
+            "x_cached": event.transaction.extras.get("cached"),
+        }
+
+        async def update_transaction():
+            async with self.engine.connect() as conn:
+                await conn.execute(
+                    update(SqlTransaction)
+                    .where(
+                        SqlTransaction.id == transaction_id,
+                    )
+                    .values(**transaction_data)
+                )
+                await conn.commit()
+
+        await self.push(update_transaction)


### PR DESCRIPTION
**Added**
 
* Cache: the hishel-based cache implementation now shares the blob storage with the rest of the application, to avoid
  duplicate work and storage.
* DX: when out of development environment, a ``start`` command stub is available so that the unadvised user does not
  wonder where it went.
* Monitoring: monitoring of background worker tasks pressure.

* Storage: audit log will now react to background worker tasks pressure by disabling storage partially or entirely based
  on the pressure amount: >10 disables content blob storage, >100 disables header blob storage, > 1000 disables message
  storage and > 10000 disables all storage for the transaction.
* Storage: added a ``NullBlobStorage`` implementation for testing purposes (or to disable blob storage easily).
 
**Changed**

* Logging: reverted the exception formatter to plain_traceback, as it's the usual default python formatter. It works
  better with external tools and is more readable because of the reduced verbosity.
* Logging: all loggers have now the WARNING default level.
* Monitoring: normalized, enhanced and complemented prometheus observability.
* Storage: SQL blob storage now keeps a LRU cache of known blobs to avoid querying the database if the answer can be closer.
* Storage: background worker queue for storage is now separated from the storage implementation.
* Storage: test fixture ``storage`` has been renamed to ``sql_storage`` for expliciteness and less linter conflicts.

**Fixed**

* Proxy: some errors happening when the server unexpectedly closes the connection although the client is waiting for
  data are now caught and logged like other network/system related errors.