### PR TITLE
👨🏼‍💻 [feat/0.9] Allow transaction body to not be stored.

### DIFF
--- a/harp/_logging.py
+++ b/harp/_logging.py
@@ -87,6 +87,7 @@ logging_config = {
         "harp_apps": {"level": _get_logging_level("harp")},
         "harp_apps.http_client": {"level": _get_logging_level("http_client")},
         "harp_apps.proxy": {"level": _get_logging_level("proxy")},
+        "harp_apps.storage.worker": {"level": _get_logging_level("proxy")},
         "httpcore": {"level": _get_logging_level("http_core")},
         "httpx": {"level": _get_logging_level("http_core")},
         "hypercorn.access": {"level": _get_logging_level("http", default="info")},

--- a/harp_apps/dashboard/tests/controllers/test_system.py
+++ b/harp_apps/dashboard/tests/controllers/test_system.py
@@ -28,8 +28,8 @@ class TestSystemController(
                 "migrate": True,
                 "url": "sqlite+aiosqlite:///:memory:",
                 "redis": None,
-                'skip_storage_requests_payload': [],
-                'skip_storage_responses_payload': [],
+                "skip_storage_requests_payload": [],
+                "skip_storage_responses_payload": [],
             },
         }
 
@@ -45,8 +45,8 @@ class TestSystemController(
                 "migrate": True,
                 "url": "sqlite+aiosqlite:///:memory:",
                 "redis": {"url": "redis://redis.example.com:1234/42"},
-                'skip_storage_requests_payload': [],
-                'skip_storage_responses_payload': [],
+                "skip_storage_requests_payload": [],
+                "skip_storage_responses_payload": [],
             },
         }
 
@@ -61,8 +61,8 @@ class TestSystemController(
                 "migrate": True,
                 "url": "sqlite+aiosqlite:///:memory:",
                 "redis": None,
-                'skip_storage_requests_payload': [],
-                'skip_storage_responses_payload': [],
+                "skip_storage_requests_payload": [],
+                "skip_storage_responses_payload": [],
             },
         }
 
@@ -77,8 +77,8 @@ class TestSystemController(
                 "url": RE(r".*://test:\*\*\*@.*"),
                 "blobs": ANY,
                 "redis": None,
-                'skip_storage_requests_payload': [],
-                'skip_storage_responses_payload': [],
+                "skip_storage_requests_payload": [],
+                "skip_storage_responses_payload": [],
             },
         }
 

--- a/harp_apps/dashboard/tests/controllers/test_system.py
+++ b/harp_apps/dashboard/tests/controllers/test_system.py
@@ -28,6 +28,8 @@ class TestSystemController(
                 "migrate": True,
                 "url": "sqlite+aiosqlite:///:memory:",
                 "redis": None,
+                'skip_storage_requests_payload': [],
+                'skip_storage_responses_payload': [],
             },
         }
 
@@ -43,6 +45,8 @@ class TestSystemController(
                 "migrate": True,
                 "url": "sqlite+aiosqlite:///:memory:",
                 "redis": {"url": "redis://redis.example.com:1234/42"},
+                'skip_storage_requests_payload': [],
+                'skip_storage_responses_payload': [],
             },
         }
 
@@ -57,6 +61,8 @@ class TestSystemController(
                 "migrate": True,
                 "url": "sqlite+aiosqlite:///:memory:",
                 "redis": None,
+                'skip_storage_requests_payload': [],
+                'skip_storage_responses_payload': [],
             },
         }
 
@@ -71,6 +77,8 @@ class TestSystemController(
                 "url": RE(r".*://test:\*\*\*@.*"),
                 "blobs": ANY,
                 "redis": None,
+                'skip_storage_requests_payload': [],
+                'skip_storage_responses_payload': [],
             },
         }
 
@@ -90,7 +98,8 @@ class TestSystemControllerThroughASGI(
         assert response["headers"] == ((b"content-type", b"application/json"),)
         assert response["body"] == (
             b'{"applications":["harp_apps.storage"],"storage":{"url":"sqlite+aiosqlite:///'
-            b':memory:","migrate":true,"blobs":{"type":"sql"},"redis":null}}'
+            b':memory:","migrate":true,"blobs":{"type":"sql"},"redis":null,'
+            b'"skip_storage_requests_payload":[],"skip_storage_responses_payload":[]}}'
         )
 
     @parametrize_with_settings({})
@@ -103,7 +112,8 @@ class TestSystemControllerThroughASGI(
         assert response["headers"] == ((b"content-type", b"application/json"),)
         assert response["body"] == (
             b'{"applications":["harp_apps.storage"],"storage":{"url":"sqlite+aiosqlite:///'
-            b':memory:","migrate":true,"blobs":{"type":"redis"},"redis":null}}'
+            b':memory:","migrate":true,"blobs":{"type":"redis"},"redis":null,'
+            b'"skip_storage_requests_payload":[],"skip_storage_responses_payload":[]}}'
         )
 
     @parametrize_with_settings(
@@ -121,7 +131,8 @@ class TestSystemControllerThroughASGI(
         assert response["headers"] == ((b"content-type", b"application/json"),)
         assert response["body"] == (
             b'{"applications":["harp_apps.storage"],"storage":{"url":"sqlite+aiosqlite:///'
-            b':memory:","migrate":true,"blobs":{"type":"sql"},"redis":null}}'
+            b':memory:","migrate":true,"blobs":{"type":"sql"},"redis":null,'
+            b'"skip_storage_requests_payload":[],"skip_storage_responses_payload":[]}}'
         )
 
     @parametrize_with_settings(
@@ -142,7 +153,8 @@ class TestSystemControllerThroughASGI(
         assert response["headers"] == ((b"content-type", b"application/json"),)
         assert response["body"] == (
             b'{"applications":["harp_apps.storage"],"storage":{"url":"sqlite+aiosqlite:///'
-            b':memory:","migrate":true,"blobs":{"type":"redis"},"redis":null}}'
+            b':memory:","migrate":true,"blobs":{"type":"redis"},"redis":null,'
+            b'"skip_storage_requests_payload":[],"skip_storage_responses_payload":[]}}'
         )
 
     @parametrize_with_database_urls("postgresql")
@@ -159,6 +171,8 @@ class TestSystemControllerThroughASGI(
                 "migrate": True,
                 "redis": None,
                 "url": RE(escape("postgresql+asyncpg://test:***@") + r".*"),
+                "skip_storage_requests_payload": [],
+                "skip_storage_responses_payload": [],
             },
         }
 
@@ -181,5 +195,6 @@ class TestSystemControllerThroughASGI(
         assert response["body"] == (
             b'{"applications":["harp_apps.storage"],"storage":{"url":"sqlite+aiosqlite:///'
             b':memory:","migrate":true,"blobs":{"type":"redis"},"redis":{"url":"redis://us'
-            b'er:***@localhost:6379/0"}}}'
+            b'er:***@localhost:6379/0"},'
+            b'"skip_storage_requests_payload":[],"skip_storage_responses_payload":[]}}'
         )

--- a/harp_apps/http_client/tests/with_storage/test_defaults.py
+++ b/harp_apps/http_client/tests/with_storage/test_defaults.py
@@ -67,8 +67,8 @@ class TestDefaultsWithStorage(BaseTestDefaultsWith):
             "migrate": ANY,
             "url": ANY,
             "redis": None,
-            'skip_storage_requests_payload': [],
-            'skip_storage_responses_payload': []
+            "skip_storage_requests_payload": [],
+            "skip_storage_responses_payload": [],
         }
 
         assert type(system.provider.get(IBlobStorage)).__name__ == "SqlBlobStorage"

--- a/harp_apps/http_client/tests/with_storage/test_defaults.py
+++ b/harp_apps/http_client/tests/with_storage/test_defaults.py
@@ -67,6 +67,8 @@ class TestDefaultsWithStorage(BaseTestDefaultsWith):
             "migrate": ANY,
             "url": ANY,
             "redis": None,
+            'skip_storage_requests_payload': [],
+            'skip_storage_responses_payload': []
         }
 
         assert type(system.provider.get(IBlobStorage)).__name__ == "SqlBlobStorage"

--- a/harp_apps/storage/services.yml
+++ b/harp_apps/storage/services.yml
@@ -19,6 +19,9 @@ services:
   - name: "storage.worker"
     description: "Storage async worker"
     base: harp_apps.storage.worker.StorageAsyncWorkerQueue
+    arguments:
+      - "skip_storage_requests_payload" : !cfg "skip_storage_requests_payload"
+        "skip_storage_responses_payload" : !cfg "skip_storage_responses_payload"
 
   - condition: [!cfg "blobs.type == 'sql'", !!bool "true"]
     services:

--- a/harp_apps/storage/settings/__init__.py
+++ b/harp_apps/storage/settings/__init__.py
@@ -12,4 +12,4 @@ class StorageSettings(DatabaseSettings):
     blobs: BlobStorageSettings = BlobStorageSettings()
     redis: Optional[RedisSettings] = None
     skip_storage_requests_payload: list[str] = Field(default_factory=list)
-    skip_storage_responses_payload:  list[str] = Field(default_factory=list)
+    skip_storage_responses_payload: list[str] = Field(default_factory=list)

--- a/harp_apps/storage/settings/__init__.py
+++ b/harp_apps/storage/settings/__init__.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from pydantic import Field
+
 from .blobs import BlobStorageSettings
 from .database import DatabaseSettings
 from .redis import RedisSettings
@@ -9,3 +11,5 @@ class StorageSettings(DatabaseSettings):
     migrate: bool = True
     blobs: BlobStorageSettings = BlobStorageSettings()
     redis: Optional[RedisSettings] = None
+    skip_storage_requests_payload: list[str] = Field(default_factory=list)
+    skip_storage_responses_payload:  list[str] = Field(default_factory=list)

--- a/harp_apps/storage/tests/test_application.py
+++ b/harp_apps/storage/tests/test_application.py
@@ -15,8 +15,8 @@ class TestStorageApplication(BaseTestForApplications):
         "migrate": True,
         "redis": None,
         "url": "sqlite+aiosqlite:///:memory:?cache=shared",
-        'skip_storage_requests_payload': [],
-        'skip_storage_responses_payload': [],
+        "skip_storage_requests_payload": [],
+        "skip_storage_responses_payload": [],
     }
 
     @pytest.mark.parametrize(

--- a/harp_apps/storage/tests/test_application.py
+++ b/harp_apps/storage/tests/test_application.py
@@ -15,6 +15,8 @@ class TestStorageApplication(BaseTestForApplications):
         "migrate": True,
         "redis": None,
         "url": "sqlite+aiosqlite:///:memory:?cache=shared",
+        'skip_storage_requests_payload': [],
+        'skip_storage_responses_payload': [],
     }
 
     @pytest.mark.parametrize(

--- a/harp_apps/storage/tests/test_settings.py
+++ b/harp_apps/storage/tests/test_settings.py
@@ -11,6 +11,8 @@ def test_empty_settings():
         "url": "sqlite+aiosqlite:///:memory:?cache=shared",
         "blobs": {"type": "sql"},
         "redis": None,
+        'skip_storage_requests_payload': [],
+        'skip_storage_responses_payload': [],
     }
 
     assert asdict(settings) == {}
@@ -24,6 +26,8 @@ def test_secure():
         "url": "postgresql+asyncpg://user:***@localhost:5432/db",
         "blobs": {"type": "sql"},
         "redis": None,
+        'skip_storage_requests_payload': [],
+        'skip_storage_responses_payload': [],
     }
 
     assert asdict(settings, mode="python") == {
@@ -35,6 +39,8 @@ def test_secure():
         "url": "postgresql+asyncpg://user:password@localhost:5432/db",
         "blobs": {"type": "sql"},
         "redis": None,
+        'skip_storage_requests_payload': [],
+        'skip_storage_responses_payload': [],
     }
 
     assert asdict(settings, secure=False) == {
@@ -49,6 +55,8 @@ def test_override_blob_storage_type():
         "url": "sqlite+aiosqlite:///:memory:?cache=shared",
         "blobs": {"type": "redis"},
         "redis": None,
+        'skip_storage_requests_payload': [],
+        'skip_storage_responses_payload': [],
     }
 
     assert asdict(settings) == {
@@ -63,6 +71,8 @@ def test_override_redis_url():
         "migrate": True,
         "redis": {"url": "redis://example.com:1234/42"},
         "url": "sqlite+aiosqlite:///:memory:?cache=shared",
+        'skip_storage_requests_payload': [],
+        'skip_storage_responses_payload': [],
     }
     assert asdict(settings) == {
         "blobs": {"type": "redis"},
@@ -74,3 +84,40 @@ def test_settings_normalization_does_not_hide_password():
     app = Application(settings_type=StorageSettings)
     settings = app.normalize({"url": "postgresql://user:password@localhost:5432/db"})
     assert settings["url"] == "postgresql+asyncpg://user:password@localhost:5432/db"
+
+
+def test_skip_storage_payload_settings():
+    settings = StorageSettings.from_kwargs(
+        skip_storage_requests_payload=["/api/uploads/*", "/health"],
+        skip_storage_responses_payload=["/api/downloads/*"]
+    )
+
+    assert asdict(settings, verbose=True) == {
+        "migrate": True,
+        "url": "sqlite+aiosqlite:///:memory:?cache=shared",
+        "blobs": {"type": "sql"},
+        "redis": None,
+        'skip_storage_requests_payload': ["/api/uploads/*", "/health"],
+        'skip_storage_responses_payload': ["/api/downloads/*"],
+    }
+
+    assert asdict(settings) == {
+        'skip_storage_requests_payload': ["/api/uploads/*", "/health"],
+        'skip_storage_responses_payload': ["/api/downloads/*"],
+    }
+
+
+def test_matches_any_pattern_matching():
+    from harp_apps.storage.worker import matches_any
+    import re
+
+    patterns = [re.compile(r"/api/uploads/.*"), re.compile(r"/health")]
+
+    # Test matching cases
+    assert matches_any("/api/uploads/file.txt", patterns) == True
+    assert matches_any("/health", patterns) == True
+    assert matches_any("/api/uploads/subfolder/image.png", patterns) == True
+
+    # Test non-matching cases
+    assert matches_any("/api/downloads/file.txt", patterns) == False
+    assert matches_any("/status", patterns) == False

--- a/harp_apps/storage/tests/test_settings.py
+++ b/harp_apps/storage/tests/test_settings.py
@@ -11,8 +11,8 @@ def test_empty_settings():
         "url": "sqlite+aiosqlite:///:memory:?cache=shared",
         "blobs": {"type": "sql"},
         "redis": None,
-        'skip_storage_requests_payload': [],
-        'skip_storage_responses_payload': [],
+        "skip_storage_requests_payload": [],
+        "skip_storage_responses_payload": [],
     }
 
     assert asdict(settings) == {}
@@ -26,8 +26,8 @@ def test_secure():
         "url": "postgresql+asyncpg://user:***@localhost:5432/db",
         "blobs": {"type": "sql"},
         "redis": None,
-        'skip_storage_requests_payload': [],
-        'skip_storage_responses_payload': [],
+        "skip_storage_requests_payload": [],
+        "skip_storage_responses_payload": [],
     }
 
     assert asdict(settings, mode="python") == {
@@ -39,8 +39,8 @@ def test_secure():
         "url": "postgresql+asyncpg://user:password@localhost:5432/db",
         "blobs": {"type": "sql"},
         "redis": None,
-        'skip_storage_requests_payload': [],
-        'skip_storage_responses_payload': [],
+        "skip_storage_requests_payload": [],
+        "skip_storage_responses_payload": [],
     }
 
     assert asdict(settings, secure=False) == {
@@ -55,8 +55,8 @@ def test_override_blob_storage_type():
         "url": "sqlite+aiosqlite:///:memory:?cache=shared",
         "blobs": {"type": "redis"},
         "redis": None,
-        'skip_storage_requests_payload': [],
-        'skip_storage_responses_payload': [],
+        "skip_storage_requests_payload": [],
+        "skip_storage_responses_payload": [],
     }
 
     assert asdict(settings) == {
@@ -71,8 +71,8 @@ def test_override_redis_url():
         "migrate": True,
         "redis": {"url": "redis://example.com:1234/42"},
         "url": "sqlite+aiosqlite:///:memory:?cache=shared",
-        'skip_storage_requests_payload': [],
-        'skip_storage_responses_payload': [],
+        "skip_storage_requests_payload": [],
+        "skip_storage_responses_payload": [],
     }
     assert asdict(settings) == {
         "blobs": {"type": "redis"},
@@ -88,8 +88,7 @@ def test_settings_normalization_does_not_hide_password():
 
 def test_skip_storage_payload_settings():
     settings = StorageSettings.from_kwargs(
-        skip_storage_requests_payload=["/api/uploads/*", "/health"],
-        skip_storage_responses_payload=["/api/downloads/*"]
+        skip_storage_requests_payload=["/api/uploads/*", "/health"], skip_storage_responses_payload=["/api/downloads/*"]
     )
 
     assert asdict(settings, verbose=True) == {
@@ -97,27 +96,28 @@ def test_skip_storage_payload_settings():
         "url": "sqlite+aiosqlite:///:memory:?cache=shared",
         "blobs": {"type": "sql"},
         "redis": None,
-        'skip_storage_requests_payload': ["/api/uploads/*", "/health"],
-        'skip_storage_responses_payload': ["/api/downloads/*"],
+        "skip_storage_requests_payload": ["/api/uploads/*", "/health"],
+        "skip_storage_responses_payload": ["/api/downloads/*"],
     }
 
     assert asdict(settings) == {
-        'skip_storage_requests_payload': ["/api/uploads/*", "/health"],
-        'skip_storage_responses_payload': ["/api/downloads/*"],
+        "skip_storage_requests_payload": ["/api/uploads/*", "/health"],
+        "skip_storage_responses_payload": ["/api/downloads/*"],
     }
 
 
 def test_matches_any_pattern_matching():
-    from harp_apps.storage.worker import matches_any
     import re
+
+    from harp_apps.storage.worker import matches_any
 
     patterns = [re.compile(r"/api/uploads/.*"), re.compile(r"/health")]
 
     # Test matching cases
-    assert matches_any("/api/uploads/file.txt", patterns) == True
-    assert matches_any("/health", patterns) == True
-    assert matches_any("/api/uploads/subfolder/image.png", patterns) == True
+    assert matches_any("/api/uploads/file.txt", patterns)
+    assert matches_any("/health", patterns)
+    assert matches_any("/api/uploads/subfolder/image.png", patterns)
 
     # Test non-matching cases
-    assert matches_any("/api/downloads/file.txt", patterns) == False
-    assert matches_any("/status", patterns) == False
+    assert not matches_any("/api/downloads/file.txt", patterns)
+    assert not matches_any("/status", patterns)

--- a/harp_apps/storage/tests/test_worker.py
+++ b/harp_apps/storage/tests/test_worker.py
@@ -7,18 +7,18 @@ from harp.utils.testing.mixins.controllers import _create_request
 from harp_apps.proxy.events import HttpMessageEvent
 from harp_apps.proxy.tests.with_storage.test_controllers_http_proxy import DispatcherTestFixtureMixin
 from harp_apps.storage.services import SqlStorage
-from harp_apps.storage.types import IStorage, IBlobStorage
-from harp_apps.storage.worker import SKIP_REQUEST_PAYLOAD_STORAGE, StorageAsyncWorkerQueue
+from harp_apps.storage.types import IBlobStorage, IStorage
 from harp_apps.storage.utils.testing.mixins import StorageTestFixtureMixin
+from harp_apps.storage.worker import SKIP_REQUEST_PAYLOAD_STORAGE, StorageAsyncWorkerQueue
 
 
 class TestStorageAsyncWorkerQueue(StorageTestFixtureMixin, DispatcherTestFixtureMixin):
     def create_worker(
-            self,
-            dispatcher: IAsyncEventDispatcher,
-            engine: AsyncEngine,
-            sql_storage: IStorage,
-            blob_storage: IBlobStorage,
+        self,
+        dispatcher: IAsyncEventDispatcher,
+        engine: AsyncEngine,
+        sql_storage: IStorage,
+        blob_storage: IBlobStorage,
     ) -> StorageAsyncWorkerQueue:
         worker = StorageAsyncWorkerQueue(
             engine,
@@ -31,10 +31,11 @@ class TestStorageAsyncWorkerQueue(StorageTestFixtureMixin, DispatcherTestFixture
         return worker
 
     async def test_skip_request_payload_storage_when_path_matches_pattern(
-            self,
-            sql_engine, blob_storage,
-            sql_storage: SqlStorage,
-            dispatcher: IAsyncEventDispatcher,
+        self,
+        sql_engine,
+        blob_storage,
+        sql_storage: SqlStorage,
+        dispatcher: IAsyncEventDispatcher,
     ):
         worker = self.create_worker(dispatcher, sql_engine, sql_storage, blob_storage)
 
@@ -44,26 +45,30 @@ class TestStorageAsyncWorkerQueue(StorageTestFixtureMixin, DispatcherTestFixture
         )
 
         transaction.markers = set()
-        
-        request = await _create_request(b"file content", method='POST', path="/api/uploads/file.txt",)
-        
+
+        request = await _create_request(
+            b"file content",
+            method="POST",
+            path="/api/uploads/file.txt",
+        )
+
         event = HttpMessageEvent(transaction, request)
-        
+
         # Mock the push method to avoid actual background processing
         worker.push = AsyncMock()
-        
+
         # Process the message
         await worker.on_transaction_message(event)
-        
+
         # Verify that the skip marker was added to the transaction
         assert SKIP_REQUEST_PAYLOAD_STORAGE in transaction.markers
 
     async def test_skip_response_payload_storage_when_marked(
-            self,
-            sql_engine,
-            blob_storage,
-            sql_storage: SqlStorage,
-            dispatcher: IAsyncEventDispatcher,
+        self,
+        sql_engine,
+        blob_storage,
+        sql_storage: SqlStorage,
+        dispatcher: IAsyncEventDispatcher,
     ):
         worker = self.create_worker(dispatcher, sql_engine, sql_storage, blob_storage)
         transaction = await self.create_transaction(
@@ -72,18 +77,22 @@ class TestStorageAsyncWorkerQueue(StorageTestFixtureMixin, DispatcherTestFixture
         )
 
         transaction.markers = set()
-        
+
         # Create a mock response message
-        request = await _create_request(b"file content", method='POST', path="/api/downloads/data.json",)
+        request = await _create_request(
+            b"file content",
+            method="POST",
+            path="/api/downloads/data.json",
+        )
 
         event = HttpMessageEvent(transaction, request)
 
         worker.push = AsyncMock()
         worker.blob_storage.put = AsyncMock()
-        
+
         # Process the message
         await worker.on_transaction_message(event)
-        
+
         # Verify that blob storage put was not called for the body
         # (it should only be called for headers, not body due to the skip marker)
         assert worker.blob_storage.put.call_count <= 1  # Only headers, not body

--- a/harp_apps/storage/tests/test_worker.py
+++ b/harp_apps/storage/tests/test_worker.py
@@ -1,0 +1,89 @@
+from unittest.mock import AsyncMock
+
+from sqlalchemy.ext.asyncio import AsyncEngine
+from whistle import IAsyncEventDispatcher
+
+from harp.utils.testing.mixins.controllers import _create_request
+from harp_apps.proxy.events import HttpMessageEvent
+from harp_apps.proxy.tests.with_storage.test_controllers_http_proxy import DispatcherTestFixtureMixin
+from harp_apps.storage.services import SqlStorage
+from harp_apps.storage.types import IStorage, IBlobStorage
+from harp_apps.storage.worker import SKIP_REQUEST_PAYLOAD_STORAGE, StorageAsyncWorkerQueue
+from harp_apps.storage.utils.testing.mixins import StorageTestFixtureMixin
+
+
+class TestStorageAsyncWorkerQueue(StorageTestFixtureMixin, DispatcherTestFixtureMixin):
+    def create_worker(
+            self,
+            dispatcher: IAsyncEventDispatcher,
+            engine: AsyncEngine,
+            sql_storage: IStorage,
+            blob_storage: IBlobStorage,
+    ) -> StorageAsyncWorkerQueue:
+        worker = StorageAsyncWorkerQueue(
+            engine,
+            sql_storage,
+            blob_storage,
+            skip_storage_requests_payload=[r"/api/uploads/.*", r"/health"],
+            skip_storage_responses_payload=[r"/api/downloads/.*"],
+        )
+        worker.register_events(dispatcher)
+        return worker
+
+    async def test_skip_request_payload_storage_when_path_matches_pattern(
+            self,
+            sql_engine, blob_storage,
+            sql_storage: SqlStorage,
+            dispatcher: IAsyncEventDispatcher,
+    ):
+        worker = self.create_worker(dispatcher, sql_engine, sql_storage, blob_storage)
+
+        transaction = await self.create_transaction(
+            sql_storage,
+            endpoint="/api/uploads/file.txt",
+        )
+
+        transaction.markers = set()
+        
+        request = await _create_request(b"file content", method='POST', path="/api/uploads/file.txt",)
+        
+        event = HttpMessageEvent(transaction, request)
+        
+        # Mock the push method to avoid actual background processing
+        worker.push = AsyncMock()
+        
+        # Process the message
+        await worker.on_transaction_message(event)
+        
+        # Verify that the skip marker was added to the transaction
+        assert SKIP_REQUEST_PAYLOAD_STORAGE in transaction.markers
+
+    async def test_skip_response_payload_storage_when_marked(
+            self,
+            sql_engine,
+            blob_storage,
+            sql_storage: SqlStorage,
+            dispatcher: IAsyncEventDispatcher,
+    ):
+        worker = self.create_worker(dispatcher, sql_engine, sql_storage, blob_storage)
+        transaction = await self.create_transaction(
+            sql_storage,
+            endpoint="/api/downloads/data.json",
+        )
+
+        transaction.markers = set()
+        
+        # Create a mock response message
+        request = await _create_request(b"file content", method='POST', path="/api/downloads/data.json",)
+
+        event = HttpMessageEvent(transaction, request)
+
+        worker.push = AsyncMock()
+        worker.blob_storage.put = AsyncMock()
+        
+        # Process the message
+        await worker.on_transaction_message(event)
+        
+        # Verify that blob storage put was not called for the body
+        # (it should only be called for headers, not body due to the skip marker)
+        assert worker.blob_storage.put.call_count <= 1  # Only headers, not body

--- a/harp_apps/storage/worker.py
+++ b/harp_apps/storage/worker.py
@@ -37,12 +37,12 @@ def matches_any(text, compiled_patterns):
 
 class StorageAsyncWorkerQueue(AsyncWorkerQueue):
     def __init__(
-            self,
-            engine: AsyncEngine,
-            storage: IStorage,
-            blob_storage: IBlobStorage,
-            skip_storage_requests_payload: list[str] | None = None,
-            skip_storage_responses_payload: list[str] | None = None,
+        self,
+        engine: AsyncEngine,
+        storage: IStorage,
+        blob_storage: IBlobStorage,
+        skip_storage_requests_payload: list[str] | None = None,
+        skip_storage_responses_payload: list[str] | None = None,
     ):
         self.engine = engine
         self.storage = storage
@@ -51,12 +51,8 @@ class StorageAsyncWorkerQueue(AsyncWorkerQueue):
         self.seen = set()
         skip_storage_requests_payload = skip_storage_requests_payload or []
         skip_storage_responses_payload = skip_storage_responses_payload or []
-        self.skip_storage_requests_payload = [
-            re.compile(pattern) for pattern in skip_storage_requests_payload
-        ]
-        self.skip_storage_responses_payload = [
-            re.compile(pattern) for pattern in skip_storage_responses_payload
-        ]
+        self.skip_storage_requests_payload = [re.compile(pattern) for pattern in skip_storage_requests_payload]
+        self.skip_storage_responses_payload = [re.compile(pattern) for pattern in skip_storage_responses_payload]
 
     def register_events(self, dispatcher: IAsyncEventDispatcher):
         dispatcher.add_listener(EVENT_TRANSACTION_STARTED, self.on_transaction_started)
@@ -108,7 +104,7 @@ class StorageAsyncWorkerQueue(AsyncWorkerQueue):
             await self.push(partial(self.blob_storage.put, headers_blob), ignore_errors=True)
             message_data["headers"] = headers_blob.id
 
-        if event.message.kind == 'request':
+        if event.message.kind == "request":
             if matches_any(event.message.path, self.skip_storage_requests_payload):
                 logger.info(f"Not storing request payload data for {serializer.summary}")
                 event.transaction.markers.add(SKIP_REQUEST_PAYLOAD_STORAGE)
@@ -116,9 +112,9 @@ class StorageAsyncWorkerQueue(AsyncWorkerQueue):
                 logger.info(f"Not storing response payload data for {serializer.summary}")
                 event.transaction.markers.add(SKIP_RESPONSE_PAYLOAD_STORAGE)
 
-        if event.message.kind == 'request' and SKIP_REQUEST_PAYLOAD_STORAGE in event.transaction.markers:
+        if event.message.kind == "request" and SKIP_REQUEST_PAYLOAD_STORAGE in event.transaction.markers:
             logger.debug("Instructed not to store payload data for request")
-        elif event.message.kind == 'response' and SKIP_RESPONSE_PAYLOAD_STORAGE in event.transaction.markers:
+        elif event.message.kind == "response" and SKIP_RESPONSE_PAYLOAD_STORAGE in event.transaction.markers:
             logger.debug("Instructed not to store payload data for response")
         else:
             # Eventually store the content blob (later)

--- a/harp_apps/storage/worker.py
+++ b/harp_apps/storage/worker.py
@@ -1,3 +1,4 @@
+import re
 from datetime import UTC
 from functools import partial
 from math import log10
@@ -6,6 +7,7 @@ from sqlalchemy import insert, update
 from sqlalchemy.ext.asyncio import AsyncEngine
 from whistle import IAsyncEventDispatcher
 
+from harp import get_logger
 from harp.http import get_serializer_for
 from harp.models import Blob
 from harp.utils.background import AsyncWorkerQueue
@@ -21,15 +23,40 @@ from harp_apps.storage.models import Transaction as SqlTransaction
 from harp_apps.storage.types import IBlobStorage, IStorage
 
 SKIP_STORAGE = "skip-storage"
+SKIP_REQUEST_PAYLOAD_STORAGE = "skip-request-payload-storage"
+SKIP_RESPONSE_PAYLOAD_STORAGE = "skip-response-payload-storage"
+
+
+logger = get_logger("harp_apps.storage.worker")
+
+
+def matches_any(text, compiled_patterns):
+    """Check if any compiled pattern matches the text"""
+    return any(pattern.search(text) for pattern in compiled_patterns)
 
 
 class StorageAsyncWorkerQueue(AsyncWorkerQueue):
-    def __init__(self, engine: AsyncEngine, storage: IStorage, blob_storage: IBlobStorage):
+    def __init__(
+            self,
+            engine: AsyncEngine,
+            storage: IStorage,
+            blob_storage: IBlobStorage,
+            skip_storage_requests_payload: list[str] | None = None,
+            skip_storage_responses_payload: list[str] | None = None,
+    ):
         self.engine = engine
         self.storage = storage
         self.blob_storage = blob_storage
         super().__init__()
         self.seen = set()
+        skip_storage_requests_payload = skip_storage_requests_payload or []
+        skip_storage_responses_payload = skip_storage_responses_payload or []
+        self.skip_storage_requests_payload = [
+            re.compile(pattern) for pattern in skip_storage_requests_payload
+        ]
+        self.skip_storage_responses_payload = [
+            re.compile(pattern) for pattern in skip_storage_responses_payload
+        ]
 
     def register_events(self, dispatcher: IAsyncEventDispatcher):
         dispatcher.add_listener(EVENT_TRANSACTION_STARTED, self.on_transaction_started)
@@ -81,11 +108,24 @@ class StorageAsyncWorkerQueue(AsyncWorkerQueue):
             await self.push(partial(self.blob_storage.put, headers_blob), ignore_errors=True)
             message_data["headers"] = headers_blob.id
 
-        # Eventually store the content blob (later)
-        if self.pressure <= 1:
-            content_blob = Blob.from_data(serializer.body, content_type=event.message.headers.get("content-type"))
-            await self.push(partial(self.blob_storage.put, content_blob), ignore_errors=True)
-            message_data["body"] = content_blob.id
+        if event.message.kind == 'request':
+            if matches_any(event.message.path, self.skip_storage_requests_payload):
+                logger.info(f"Not storing request payload data for {serializer.summary}")
+                event.transaction.markers.add(SKIP_REQUEST_PAYLOAD_STORAGE)
+            if matches_any(event.message.path, self.skip_storage_responses_payload):
+                logger.info(f"Not storing response payload data for {serializer.summary}")
+                event.transaction.markers.add(SKIP_RESPONSE_PAYLOAD_STORAGE)
+
+        if event.message.kind == 'request' and SKIP_REQUEST_PAYLOAD_STORAGE in event.transaction.markers:
+            logger.debug("Instructed not to store payload data for request")
+        elif event.message.kind == 'response' and SKIP_RESPONSE_PAYLOAD_STORAGE in event.transaction.markers:
+            logger.debug("Instructed not to store payload data for response")
+        else:
+            # Eventually store the content blob (later)
+            if self.pressure <= 1:
+                content_blob = Blob.from_data(serializer.body, content_type=event.message.headers.get("content-type"))
+                await self.push(partial(self.blob_storage.put, content_blob), ignore_errors=True)
+                message_data["body"] = content_blob.id
 
         async def create_message():
             async with self.engine.connect() as conn:


### PR DESCRIPTION
Hi everyone! 

We would like to use Harp-proxy in our stack but we have some routes for which we dont' want to store the payload (nor display it in the dashboard). 
As we've not seen the feature available in Harp, we decided to develop it. 

This brings a new config:

```yaml
storage:
    skip_storage_requests_payload:
        - '/api/uploads/.*'
        - '/health'
    skip_storage_responses_payload:
        - '/api/downloads/.*'
```

What it does is that at the worker level, if a transaction matches one of those patterns (request and/or response), we skip writing the body. 

This in turn will also not display it in the dashboard. 

I'm not completely comfortable with the mechanism used to instantiate harp_apps and workers, and I hope I've not made any big mistake.
I've added some basic tests (settings and behavior) also, I think they describe the wanted behavior properly. 

Let me know what you think of this, I'm fully open to change the way it's done and/or change some more minor details. 

Regards, 
Manuel VIVES 