### PR TITLE
👨🏼‍💻 [feat/0.9] Allow transaction body to not be stored. [V2]

### DIFF
--- a/docs/apps/rules/recipes.rst
+++ b/docs/apps/rules/recipes.rst
@@ -14,3 +14,21 @@ Force some (sub) endpoints to cache the response for a given time
             "GET /foo/bar":
                 on_remote_response:
                     response.headers['Cache-Control'] = 'max-age=3600'
+
+
+Disable the storing of payload for requests
+-----------------------------------------------------------------
+
+There are two markers (`skip-request-payload-storage` and `skip-response-payload-storage`) that
+allows to disable the storing of payload. They are used respectively for the Request part (payload sent upstream)
+and the Response part (response from upstream).
+
+.. code-block:: yaml
+
+    rules:
+      "my-endpoint":
+        "POST /upload":
+          on_request: |
+            transaction.markers.add("skip-request-payload-storage")
+          on_response: |
+            transaction.markers.add("skip-response-payload-storage")

--- a/docs/changelogs/unreleased.rst
+++ b/docs/changelogs/unreleased.rst
@@ -18,6 +18,7 @@ Changed
 - Simplified Dockerfile to single-stage wheel-based build matching CI/CD process
 - Local Docker builds (``make buildc``) now build wheel first then install in container, consistent with CI
 - Removed development Docker image targets (``buildc-dev``, ``runc-dev-shell``, ``testc-*``) - tests run natively
+- Add markers to disable storing for requests/response payload (`skip-request-payload-storage` and `skip-response-payload-storage`)
 
 Added
 -----

--- a/harp/_logging.py
+++ b/harp/_logging.py
@@ -87,6 +87,7 @@ logging_config = {
         "harp_apps": {"level": _get_logging_level("harp")},
         "harp_apps.http_client": {"level": _get_logging_level("http_client")},
         "harp_apps.proxy": {"level": _get_logging_level("proxy")},
+        "harp_apps.storage": {"level": _get_logging_level("storage")},
         "httpcore": {"level": _get_logging_level("http_core")},
         "httpx": {"level": _get_logging_level("http_core")},
         "hypercorn.access": {"level": _get_logging_level("http", default="info")},

--- a/harp_apps/storage/worker.py
+++ b/harp_apps/storage/worker.py
@@ -6,6 +6,7 @@ from sqlalchemy import insert, update
 from sqlalchemy.ext.asyncio import AsyncEngine
 from whistle import IAsyncEventDispatcher
 
+from harp import get_logger
 from harp.http import get_serializer_for
 from harp.models import Blob
 from harp.utils.background import AsyncWorkerQueue
@@ -21,6 +22,11 @@ from harp_apps.storage.models import Transaction as SqlTransaction
 from harp_apps.storage.types import IBlobStorage, IStorage
 
 SKIP_STORAGE = "skip-storage"
+SKIP_REQUEST_PAYLOAD_STORAGE = "skip-request-payload-storage"
+SKIP_RESPONSE_PAYLOAD_STORAGE = "skip-response-payload-storage"
+
+
+logger = get_logger("harp_apps.storage.worker")
 
 
 class StorageAsyncWorkerQueue(AsyncWorkerQueue):
@@ -81,11 +87,20 @@ class StorageAsyncWorkerQueue(AsyncWorkerQueue):
             await self.push(partial(self.blob_storage.put, headers_blob), ignore_errors=True)
             message_data["headers"] = headers_blob.id
 
-        # Eventually store the content blob (later)
-        if self.pressure <= 1:
-            content_blob = Blob.from_data(serializer.body, content_type=event.message.headers.get("content-type"))
-            await self.push(partial(self.blob_storage.put, content_blob), ignore_errors=True)
-            message_data["body"] = content_blob.id
+        if event.message.kind == "request" and SKIP_REQUEST_PAYLOAD_STORAGE in event.transaction.markers:
+            logger.debug(
+                "Skipping storing Request payload", transaction_id=event.transaction.id, summary=serializer.summary
+            )
+        elif event.message.kind == "response" and SKIP_RESPONSE_PAYLOAD_STORAGE in event.transaction.markers:
+            logger.debug(
+                "Skipping storing Response payload", transaction_id=event.transaction.id, summary=serializer.summary
+            )
+        else:
+            # Eventually store the content blob (later)
+            if self.pressure <= 1:
+                content_blob = Blob.from_data(serializer.body, content_type=event.message.headers.get("content-type"))
+                await self.push(partial(self.blob_storage.put, content_blob), ignore_errors=True)
+                message_data["body"] = content_blob.id
 
         async def create_message():
             async with self.engine.connect() as conn:


### PR DESCRIPTION
In case someone is using harp to process requests for which they don't want the body to be stored (for compliance, security, ...) they can now add transaction markers (`skip-request-payload-storage` & `skip-response-payload-storage`) through the rules engine so that the storage worker will skip storing the payload for those transactions.

This is the V2 of the PR #753