### PR TITLE
fix(docs): point README CI badge and link to GitHub Actions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,9 +12,9 @@ of the APIs you use. It runs in your infrastructure, close to your applications.
     :target: https://artifacthub.io/packages/helm/harp/harp-proxy
     :alt: Artifact Hub
 
-.. image:: https://www.gitlab.com/makersquad/oss/harp/badges/0.9/pipeline.svg
-    :target: https://www.gitlab.com/makersquad/oss/harp/pipelines
-    :alt: GitLab CI/CD Pipeline Status
+.. image:: https://github.com/msqd/harp/actions/workflows/cicd.yml/badge.svg
+    :target: https://github.com/msqd/harp/actions/workflows/cicd.yml
+    :alt: CI/CD Pipeline Status
 
 .. image:: https://readthedocs.org/projects/harp-proxy/badge/?version=0.9
     :target: https://docs.harp-project.net/en/0.9/
@@ -31,7 +31,7 @@ of the APIs you use. It runs in your infrastructure, close to your applications.
 | `Install (Docker) <https://docs.harp-project.net/en/latest/start/docker.html>`_
 | `Install (PIP) <https://docs.harp-project.net/en/latest/start/python.html>`_
 | `Repository (Git) <https://github.com/msqd/harp>`_
-| `CI/CD <https://gitlab.com/makersquad/oss/harp/-/pipelines>`_
+| `CI/CD <https://github.com/msqd/harp/actions/workflows/cicd.yml>`_
 
 **Community**: |badge_list| |badge_discord| |badge_contributors|
 

--- a/docs/changelogs/unreleased.rst
+++ b/docs/changelogs/unreleased.rst
@@ -1,2 +1,7 @@
 Unreleased
 ==========
+
+Fixed
+:::::
+
+- Replaced the dead GitLab CI/CD pipeline badge and stale "CI/CD" link in the README with the GitHub Actions workflow, aligning the public docs with where CI actually runs since 0.9.0


### PR DESCRIPTION
## What

The README still advertised CI on GitLab, which has been dead since CI/CD moved to GitHub Actions in 0.9.0:

- the top-of-README pipeline badge sourced from `gitlab.com/.../pipeline.svg` rendered as a broken image;
- the "CI/CD" quick-link pointed at the old GitLab pipelines page.

This repoints both at the `cicd.yml` GitHub Actions workflow, so the badge loads and reflects real CI status, and the link resolves to the Actions page.

## Value

The README is the first thing a visitor or potential contributor sees — a broken badge and a stale link make a poor first impression and misrepresent where CI runs. Public-facing scope only.

## Verification (acceptance criteria)

- [x] No GitLab/broken CI badge remains in `README.rst`; the badge reflects GitHub Actions status.
- [x] The "CI/CD" link resolves to the GitHub Actions workflows page.
- [x] `grep -ri gitlab` over public docs returns no CI/CD references (migration changelog entries kept).
- [x] Badge image loads — `badge.svg` returns `HTTP 200 image/svg+xml`; README renders in reStructuredText without errors.

Closes #817