### PR TITLE
fix(tests): correct env-polluted storage snapshot for repositories example

### DIFF
--- a/harp/config/tests/__snapshots__/test_all_examples.ambr
+++ b/harp/config/tests/__snapshots__/test_all_examples.ambr
@@ -839,8 +839,7 @@
         endpoints:
         - url: https://registry.yarnpkg.com/
   rules: {}
-  storage:
-    url: postgresql+asyncpg://harp:harp@127.0.0.1/repositories
+  storage: {}
   
   '''
 # ---


### PR DESCRIPTION
## What

Fixes a red `Test Backend Core (Py3.13)` on the default branch (stop-the-line — blocks every PR merge). See #819.

`harp/config/examples/repositories.yml` has no `storage` section, so it must serialize to the default `storage: {}` like all 42 sibling examples. The snapshot instead held a concrete `postgresql+asyncpg://harp:harp@127.0.0.1/repositories` DSN — recorded (back in the 2024-08 pydantic settings refactor) on a machine that had a `STORAGE__URL` env var set. It stayed latent until the default storage serialization settled on `{}`, then started failing in clean CI.

This regenerates the single affected snapshot; test-only, no runtime behavior changes.

## Verification

- [x] `test_load_example[repositories]` passes; full `test_all_examples.py` green (43 snapshots).
- [x] `harp/config/tests/` green (165 passed); `ruff` clean.
- [x] No env-specific DSN remains in `test_all_examples.ambr`.

Closes #819