### PR TITLE
chore(build): exclude test code from wheel distributions

### DIFF
--- a/docs/changelogs/unreleased.rst
+++ b/docs/changelogs/unreleased.rst
@@ -1,6 +1,11 @@
 Unreleased
 ==========
 
+Changed
+:::::::
+
+- The published wheel no longer ships test code, snapshots or dev-only testing utilities, reducing the distribution size (the ``harp create project`` scaffolding, which legitimately contains tests, is preserved).
+
 Fixed
 :::::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,19 @@ include = [
 exclude = [
     "**/node_modules/",
     "harp_apps/dashboard/frontend",
+    # Test code and dev-only utilities: not needed to run HARP in production.
+    "**/tests/",
+    "**/test_*.py",
+    "**/*_test.py",
+    "**/testing/",
+    "**/conftest.py",
+    "**/__snapshots__/",
+    "**/__pycache__/",
+    "**/*.pyc",
+    # Keep the project scaffolding shipped by `harp create project`: the
+    # cookiecutter template legitimately contains tests/ and conftest.py that
+    # end up in the user's generated project.
+    "!harp/commandline/cookiecutters/**",
 ]
 
 [tool.hatch.build.targets.wheel.force-include]

--- a/tests/test_wheel_packaging.py
+++ b/tests/test_wheel_packaging.py
@@ -1,0 +1,65 @@
+"""Guards the wheel distribution contents.
+
+Test code and dev-only utilities must not ship in the wheel (they bloat the
+distribution and expose internal helpers), while the project scaffolding shipped
+by ``harp create project`` — which legitimately contains ``tests/`` and
+``conftest.py`` — must be preserved.
+
+These assertions run against Hatchling's own file-selection logic, so they check
+the real include/exclude rules from ``pyproject.toml`` without building a wheel
+(no network, no frontend build required).
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Matches Python test code and dev-only testing utilities.
+TEST_FILE = re.compile(
+    r"(^|/)(tests|testing|__snapshots__)/|(^|/)conftest\.py$|(^|/)test_[^/]*\.py$|_test\.py$"
+)
+
+# The cookiecutter templates ship as production scaffolding; their own tests/ and
+# conftest.py belong in the generated user project and must stay in the wheel.
+TEMPLATE_PREFIX = "harp/commandline/cookiecutters/"
+
+
+def _wheel_distribution_paths():
+    pytest.importorskip("hatchling.builders.wheel")
+    from hatchling.builders.wheel import WheelBuilder
+
+    if not (REPO_ROOT / "pyproject.toml").exists():
+        pytest.skip("not a source checkout")
+
+    builder = WheelBuilder(str(REPO_ROOT))
+    return {f.distribution_path for f in builder.recurse_included_files()}
+
+
+def test_wheel_excludes_python_test_code():
+    """No test files or testing utilities leak into the wheel (cookiecutter templates aside)."""
+    paths = _wheel_distribution_paths()
+    leaked = sorted(
+        p
+        for p in paths
+        if p.endswith(".py") and TEST_FILE.search(p) and not p.startswith(TEMPLATE_PREFIX)
+    )
+    assert leaked == [], f"test code should not ship in the wheel: {leaked}"
+
+
+def test_wheel_keeps_cookiecutter_template_scaffolding():
+    """The generated-project scaffolding (incl. its tests/ and conftest.py) stays shipped."""
+    paths = _wheel_distribution_paths()
+    template_tests = [
+        p for p in paths if p.startswith(TEMPLATE_PREFIX) and ("/tests/" in p or p.endswith("conftest.py"))
+    ]
+    assert template_tests, "cookiecutter template test scaffolding must remain in the wheel"
+
+
+def test_wheel_keeps_production_modules():
+    """Excluding tests must not drop production code."""
+    paths = _wheel_distribution_paths()
+    for module in ("harp/__init__.py", "harp/config/__init__.py", "harp_apps/proxy/__init__.py"):
+        assert module in paths, f"production module missing from wheel: {module}"


### PR DESCRIPTION
## What

The published wheel shipped internal test code: every `tests/` directory, `__snapshots__`, `conftest.py`, `test_*.py`, and the dev-only `harp.utils.testing` / `harp_apps.storage.utils.testing` packages — code end users never run (~170KB, 944KB → 776KB locally). This adds Hatchling wheel `exclude` patterns to drop them.

### Guarding the project template
`harp/commandline/cookiecutters/` ships as production scaffolding, and it legitimately contains `tests/` and `conftest.py` that must land in the user's generated project. A negation pattern (`!harp/commandline/cookiecutters/**`) keeps the template intact — verified no production code imports the excluded testing utilities.

## Tests

`tests/test_wheel_packaging.py` drives Hatchling's own file-selection (no wheel build, no network, no frontend build needed):
- no Python test code / testing utilities ship (outside the template),
- the cookiecutter template's test scaffolding is preserved,
- production modules remain.

## Out of scope / follow-up

`harp_apps/dashboard/web/src/` contains 181 `.d.ts` TypeScript declaration files (incl. frontend test mocks) with **zero** runtime files. They arrive via `force-include` of the built dashboard (which bypasses `exclude`), so they can't be dropped from `pyproject.toml` — the frontend build shouldn't emit declarations into the served `web/` dir. Tracking separately; not addressed here to keep this change focused.

Closes #804