### PR TITLE
feat(create): add 'make dev' auto-reload task to project template

### DIFF
--- a/docs/changelogs/unreleased.rst
+++ b/docs/changelogs/unreleased.rst
@@ -5,6 +5,7 @@ Added
 :::::
 
 - ``harp create project`` now accepts the project name as an argument and ``--no-app`` / ``--no-config`` flags to skip the application folder or the config file, running without interactive prompts when the name and git author (from ``git config``) are available. New projects are created with an application folder by default.
+- New ``make dev`` task in generated projects: starts the HARP proxy with auto-reload on file changes (watches the application package and/or ``config.yml``), powered by ``watchfiles``.
 
 Changed
 :::::::

--- a/harp/commandline/cookiecutters/project/{{cookiecutter.__dir_name}}/Makefile
+++ b/harp/commandline/cookiecutters/project/{{cookiecutter.__dir_name}}/Makefile
@@ -32,8 +32,12 @@ install:  ## Install dependencies using UV
 start: install  ## Start the HARP proxy server
 	$(call execute,$(UV) run harp-proxy server{% if cookiecutter.create_application %} --enable {{cookiecutter.__pkg_name}}{% endif %}{% if cookiecutter.create_config %} --file config.yml{% endif %} $(HARP_OPTIONS))
 
+# watchfiles runs 'harp-proxy server' directly (not through a nested 'uv run'): it must supervise
+# the server process itself so its restart signal reaches it and the port is released before the
+# reload. A wrapper process would absorb the signal, leaving the old server bound and the reload
+# failing with "address already in use". The outer 'uv run watchfiles' already provides the venv.
 dev: install  ## Start the HARP proxy server with auto-reload on file changes
-	$(call execute,$(UV) run watchfiles "$(UV) run harp-proxy server{% if cookiecutter.create_application %} --enable {{cookiecutter.__pkg_name}}{% endif %}{% if cookiecutter.create_config %} --file config.yml{% endif %} $(HARP_OPTIONS)"{% if cookiecutter.create_application %} {{cookiecutter.__pkg_name}}/{% endif %}{% if cookiecutter.create_config %} config.yml{% endif %})
+	$(call execute,$(UV) run watchfiles "harp-proxy server{% if cookiecutter.create_application %} --enable {{cookiecutter.__pkg_name}}{% endif %}{% if cookiecutter.create_config %} --file config.yml{% endif %} $(HARP_OPTIONS)"{% if cookiecutter.create_application %} {{cookiecutter.__pkg_name}}/{% endif %}{% if cookiecutter.create_config %} config.yml{% endif %})
 
 test: install  ## Run tests with pytest
 	$(call execute,$(UV) run pytest)

--- a/harp/commandline/cookiecutters/project/{{cookiecutter.__dir_name}}/Makefile
+++ b/harp/commandline/cookiecutters/project/{{cookiecutter.__dir_name}}/Makefile
@@ -16,7 +16,7 @@ endef
 # Default target
 .DEFAULT_GOAL := help
 
-.PHONY: help install start test clean
+.PHONY: help install start dev test clean
 
 help:  ## Shows this help message
 	@echo "📦 \033[1m{{cookiecutter.name}}\033[0m"
@@ -31,6 +31,9 @@ install:  ## Install dependencies using UV
 
 start: install  ## Start the HARP proxy server
 	$(call execute,$(UV) run harp-proxy server{% if cookiecutter.create_application %} --enable {{cookiecutter.__pkg_name}}{% endif %}{% if cookiecutter.create_config %} --file config.yml{% endif %} $(HARP_OPTIONS))
+
+dev: install  ## Start the HARP proxy server with auto-reload on file changes
+	$(call execute,$(UV) run watchfiles "$(UV) run harp-proxy server{% if cookiecutter.create_application %} --enable {{cookiecutter.__pkg_name}}{% endif %}{% if cookiecutter.create_config %} --file config.yml{% endif %} $(HARP_OPTIONS)"{% if cookiecutter.create_application %} {{cookiecutter.__pkg_name}}/{% endif %}{% if cookiecutter.create_config %} config.yml{% endif %})
 
 test: install  ## Run tests with pytest
 	$(call execute,$(UV) run pytest)

--- a/harp/commandline/cookiecutters/project/{{cookiecutter.__dir_name}}/pyproject.toml
+++ b/harp/commandline/cookiecutters/project/{{cookiecutter.__dir_name}}/pyproject.toml
@@ -11,6 +11,11 @@ dependencies = [
     "harp-proxy",
 ]
 
+[dependency-groups]
+dev = [
+    "watchfiles",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -418,6 +418,21 @@ class TestMakefileDevTarget:
             "dev target should watch config.yml when it is created"
         )
 
+    def test_dev_target_runs_server_directly_without_nested_uv_run(self, makefile_content):
+        """watchfiles must supervise the server process itself so the port is freed before reload.
+
+        A nested ``uv run`` wrapper absorbs watchfiles' restart signal and leaves the old server
+        bound, so the reload fails with "address already in use" (observed on macOS). The outer
+        ``uv run watchfiles`` already provides the environment.
+        """
+        recipe = _dev_recipe(makefile_content)
+        assert 'watchfiles "harp-proxy server' in recipe, (
+            "watchfiles should run 'harp-proxy server' directly as its child process"
+        )
+        assert "run harp-proxy" not in recipe, (
+            "the watched command must not nest another 'uv run' (it would absorb the reload signal)"
+        )
+
 
 class TestPyprojectWatchfilesDependency:
     """Test watchfiles is declared so 'make dev' resolves it after 'uv sync'."""

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -365,3 +365,73 @@ class TestCookiecutterPrompts:
 
         for var in user_variables:
             assert var in prompts, f"User-facing variable '{var}' should have a custom prompt"
+
+
+def _dev_recipe(makefile_content):
+    """Return the recipe lines of the Makefile 'dev' target (empty string if absent)."""
+    lines = makefile_content.splitlines()
+    for i, line in enumerate(lines):
+        if line.startswith("dev:"):
+            recipe = []
+            for following in lines[i + 1 :]:
+                if following.startswith("\t"):
+                    recipe.append(following)
+                elif following.strip() == "":
+                    continue
+                else:
+                    break
+            return "\n".join(recipe)
+    return ""
+
+
+class TestMakefileDevTarget:
+    """Test the 'dev' target provides auto-reload via watchfiles."""
+
+    @pytest.fixture
+    def makefile_content(self):
+        return (TEMPLATE_PROJECT_DIR / "Makefile").read_text()
+
+    def test_dev_target_exists_and_installs_first(self, makefile_content):
+        """A 'dev' target exists and depends on install (deps available before running)."""
+        assert re.search(r"(?m)^dev:\s.*install", makefile_content), (
+            "Makefile should define a 'dev' target depending on install"
+        )
+
+    def test_dev_target_is_phony(self, makefile_content):
+        """'dev' is declared as a phony target."""
+        phony_lines = [line for line in makefile_content.splitlines() if line.startswith(".PHONY")]
+        assert any("dev" in line.split() for line in phony_lines), "'dev' should be listed in .PHONY"
+
+    def test_dev_target_runs_server_with_watchfiles(self, makefile_content):
+        """The dev recipe runs the harp-proxy server through watchfiles for auto-reload."""
+        recipe = _dev_recipe(makefile_content)
+        assert "watchfiles" in recipe, "dev target should use watchfiles"
+        assert "harp-proxy server" in recipe, "dev target should run the harp-proxy server"
+
+    def test_dev_target_watches_app_and_config_conditionally(self, makefile_content):
+        """The dev recipe watches the app package and/or config.yml, guarded by the create flags."""
+        recipe = _dev_recipe(makefile_content)
+        assert "{% if cookiecutter.create_application %}" in recipe and "{{cookiecutter.__pkg_name}}/" in recipe, (
+            "dev target should watch the application package when it is created"
+        )
+        assert "{% if cookiecutter.create_config %}" in recipe and "config.yml" in recipe, (
+            "dev target should watch config.yml when it is created"
+        )
+
+
+class TestPyprojectWatchfilesDependency:
+    """Test watchfiles is declared so 'make dev' resolves it after 'uv sync'."""
+
+    @pytest.fixture
+    def pyproject_content(self):
+        return (TEMPLATE_PROJECT_DIR / "pyproject.toml").read_text()
+
+    def test_watchfiles_declared_as_dev_dependency(self, pyproject_content):
+        """watchfiles is declared in the dev dependency group uv installs by default (not a plain extra).
+
+        Parsed as text: the template embeds Jinja conditionals that are not valid TOML.
+        """
+        assert "[dependency-groups]" in pyproject_content, "should declare a [dependency-groups] table"
+        assert re.search(r"(?s)\[dependency-groups\].*?dev\s*=\s*\[[^\]]*watchfiles", pyproject_content), (
+            "watchfiles should be listed in the [dependency-groups] dev group so 'uv sync' installs it"
+        )


### PR DESCRIPTION
## What

Generated projects (`harp create project`) gain a **`make dev`** target that runs the HARP proxy through `watchfiles` and restarts it on file changes — watching the application package and/or `config.yml` per the create flags. This removes the manual restart loop during development.

## Notes on the implementation

- **Dependency declaration:** `watchfiles` is **not** a runtime dependency of `harp-proxy`, and `[project.optional-dependencies]` extras are **not** installed by a plain `uv sync`. So watchfiles is declared under `[dependency-groups] dev` (PEP 735), which `uv sync` installs by default — `make dev` works out of the box with the existing `install` target.
- **Watch paths** follow the same Jinja conditionals as `start`: the app package (`{{ pkg }}/`) when `--app`, `config.yml` when `--config`. No `--filter python`, so config edits also trigger reloads.

## Tests

Added to `tests/test_cookiecutter_template.py`:
- `dev` target exists, depends on `install`, is `.PHONY`, runs the server through watchfiles;
- watch paths are guarded by the create flags;
- watchfiles is declared in the `dev` dependency group.

Verified by real cookiecutter generation across all four flag combinations (app+config, config-only, app-only, neither): each renders a correct `dev` recipe and valid TOML.

Closes #811