### PR TITLE
refactor(create): run cookiecutter via subprocess with uv fallback, drop Poetry

### DIFF
--- a/docs/changelogs/unreleased.rst
+++ b/docs/changelogs/unreleased.rst
@@ -6,6 +6,7 @@ Changed
 
 - **BC break:** renamed the ``harp.typing`` package to ``harp.typedefs`` so a first-party module no longer shadows the standard-library ``typing`` module (which crashed the CLI when the ``harp/`` directory ended up on ``sys.path``). Update imports from ``harp.typing`` to ``harp.typedefs``.
 - The published wheel no longer ships test code, snapshots or dev-only testing utilities, reducing the distribution size (the ``harp create project`` scaffolding, which legitimately contains tests, is preserved).
+- ``harp create`` now runs cookiecutter as a subprocess, falling back to ``uv tool run cookiecutter`` when it is not installed as a package, and its guidance no longer mentions Poetry (completes the UV migration for the project bootstrap tooling).
 
 Fixed
 :::::

--- a/harp/commandline/create.py
+++ b/harp/commandline/create.py
@@ -1,10 +1,12 @@
 import os
+import shutil
+import subprocess
 from typing import cast
 
 from click import BaseCommand
 
 from harp.commandline import cookiecutters as templates
-from harp.utils.commandline import check_packages, click
+from harp.utils.commandline import click
 
 
 @click.command("create", short_help="Creates a templated directory using cookiecutter (project...).")
@@ -12,15 +14,17 @@ from harp.utils.commandline import check_packages, click
 def create(template):
     """Creates a new project using cookiecutter."""
 
-    if not check_packages("cookiecutter"):
+    template_path = os.path.join(templates.__path__[0], template)
+
+    if shutil.which("cookiecutter"):
+        subprocess.run(["cookiecutter", template_path], check=True)
+    elif shutil.which("uv"):
+        subprocess.run(["uv", "tool", "run", "cookiecutter", template_path], check=True)
+    else:
         raise click.UsageError(
-            "You need to install cookiecutter to use this command (or use the `dev` extra, for example using "
-            "`pip install harp-proxy[dev]` or `poetry install -E dev`)."
+            "Install cookiecutter with `uv add harp-proxy --extra dev`, or ensure `uv` is available to "
+            "run it via `uv tool run`."
         )
-
-    from cookiecutter.main import cookiecutter
-
-    cookiecutter(os.path.join(templates.__path__[0], template))
 
 
 create = cast(BaseCommand, create)

--- a/harp/commandline/tests/test_create.py
+++ b/harp/commandline/tests/test_create.py
@@ -1,0 +1,51 @@
+"""Tests for the `harp create` command's cookiecutter invocation (subprocess, uv fallback)."""
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from harp.commandline.create import create
+
+
+def _invoke(which_map):
+    """Invoke `create project` with shutil.which stubbed from which_map, capturing subprocess.run."""
+    with (
+        patch("harp.commandline.create.shutil.which", side_effect=lambda name: which_map.get(name)),
+        patch("harp.commandline.create.subprocess.run") as run,
+    ):
+        result = CliRunner().invoke(create, ["project"])
+    return result, run
+
+
+class TestCreateCookiecutterInvocation:
+    def test_runs_cookiecutter_binary_when_available(self):
+        result, run = _invoke({"cookiecutter": "/usr/bin/cookiecutter", "uv": "/usr/bin/uv"})
+        assert result.exit_code == 0, result.output
+        run.assert_called_once()
+        args = run.call_args.args[0]
+        assert args[0] == "cookiecutter"
+        assert args[-1].endswith("project")
+
+    def test_falls_back_to_uv_tool_run_when_cookiecutter_absent(self):
+        result, run = _invoke({"cookiecutter": None, "uv": "/usr/bin/uv"})
+        assert result.exit_code == 0, result.output
+        run.assert_called_once()
+        args = run.call_args.args[0]
+        assert args[:4] == ["uv", "tool", "run", "cookiecutter"]
+        assert args[-1].endswith("project")
+
+    def test_errors_with_uv_message_when_nothing_available(self):
+        result, run = _invoke({"cookiecutter": None, "uv": None})
+        assert result.exit_code != 0
+        run.assert_not_called()
+        assert "uv" in result.output.lower()
+        assert "poetry" not in result.output.lower()
+
+
+class TestDocsProcessCommand:
+    def test_docs_executable_uses_uv_not_poetry(self):
+        from harp.commandline.utils.manager import HonchoManagerFactory
+
+        _cwd, command = HonchoManagerFactory()._get_docs_executable(None)
+        assert "uv run" in command
+        assert "poetry" not in command.lower()

--- a/harp/commandline/utils/manager.py
+++ b/harp/commandline/utils/manager.py
@@ -91,7 +91,7 @@ class HonchoManagerFactory:
         # todo add check available
         return (
             os.path.join(ROOT_DIR, "docs"),
-            "poetry run sphinx-autobuild . _build/html",
+            "uv run sphinx-autobuild . _build/html",
         )
 
     commands[HARP_DOCS_SERVICE] = _get_docs_executable


### PR DESCRIPTION
## What

Completes the UV migration for the project bootstrap tooling.

- `harp create` now runs cookiecutter as a **subprocess**: the `cookiecutter` binary when available, otherwise a fallback to `uv tool run cookiecutter`. No more importing cookiecutter as a Python module — both paths behave identically and the `uv tool run` fallback works without cookiecutter installed.
- The "not available" error now points at **uv** (`uv add harp-proxy --extra dev` / `uv tool run`) instead of `poetry install -E dev`.
- The docs autobuild process command switches from `poetry run sphinx-autobuild` to `uv run sphinx-autobuild`.

No Poetry references remain in the CLI source.

This establishes the subprocess invocation that #809 builds on (passing project name / author / flags as `key=value` extra-context with `--no-input`).

## Tests

`harp/commandline/tests/test_create.py`:
- runs the `cookiecutter` binary when present;
- falls back to `uv tool run cookiecutter` when absent;
- errors with a uv-based message (no Poetry) when neither is available;
- the docs process command uses `uv run`, not Poetry.

Closes #808