### PR TITLE
fix(cli): restore 'harp' console script so the CLI runs from a checkout

### DIFF
--- a/docs/changelogs/unreleased.rst
+++ b/docs/changelogs/unreleased.rst
@@ -5,3 +5,4 @@ Fixed
 :::::
 
 - Replaced the dead GitLab CI/CD pipeline badge and stale "CI/CD" link in the README with the GitHub Actions workflow, aligning the public docs with where CI actually runs since 0.9.0
+- Restored the ``harp`` command as an alias of ``harp-proxy`` so ``harp ...`` and ``uv run harp ...`` run the CLI instead of executing the package directory (which shadowed the stdlib ``typing`` module and crashed from a source checkout); the documented ``harp create project`` flow now works.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
 
 [project.scripts]
 harp-proxy = "harp.commandline:entrypoint"
+harp = "harp.commandline:entrypoint"
 
 [dependency-groups]
 dev = [

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -1,0 +1,65 @@
+"""Regression tests for running the HARP CLI from a source checkout.
+
+Guards against the class of failure where the ``harp/`` package directory ends
+up on ``sys.path`` and shadows a stdlib module (e.g. ``harp/typing`` vs stdlib
+``typing``). This happened because ``harp`` had no console entry point, so
+``uv run harp ...`` executed the package *directory* instead of a script.
+
+The CLI must import cleanly through the supported invocations: the ``harp``
+console script and ``python -m harp`` from the repository root.
+"""
+
+import os
+import subprocess
+import sys
+from importlib.metadata import entry_points
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _console_script(name):
+    """Path to an installed console script sitting next to the interpreter."""
+    candidate = Path(sys.executable).parent / name
+    return candidate if candidate.exists() else None
+
+
+def test_harp_and_harp_proxy_console_scripts_are_registered():
+    names = {ep.name for ep in entry_points(group="console_scripts")}
+    assert "harp-proxy" in names, "harp-proxy console script must exist"
+    assert "harp" in names, "the 'harp' console script must exist (documented as `harp create project`)"
+
+
+def test_harp_console_script_runs_without_stdlib_shadow():
+    """`harp version` must import and run — this is what `uv run harp` resolves to."""
+    harp = _console_script("harp")
+    if harp is None:
+        pytest.skip("harp console script not installed in this environment")
+    result = subprocess.run([str(harp), "version"], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert "harp" in (result.stdout + result.stderr).lower()
+
+
+def test_harp_create_help_imports_cleanly():
+    """The documented `harp create` command imports without the typing shadow."""
+    harp = _console_script("harp")
+    if harp is None:
+        pytest.skip("harp console script not installed in this environment")
+    result = subprocess.run([str(harp), "create", "--help"], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+def test_python_dash_m_harp_runs_from_repo_root():
+    """`python -m harp` from the repo root keeps the repo root (not harp/) on sys.path."""
+    env = {**os.environ, "PYTHONPATH": ""}
+    result = subprocess.run(
+        [sys.executable, "-m", "harp", "version"],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "harp" in (result.stdout + result.stderr).lower()


### PR DESCRIPTION
## Stop-the-line — closes #825

Running the CLI as `harp ...` or `uv run harp ...` crashed from a source checkout with an `ImportError` (`from typing import TYPE_CHECKING`). Root cause: there was **no `harp` console script** (only `harp-proxy`), so `uv run harp` executed the package **directory**, putting `harp/` on `sys.path[0]` — which made `harp/typing/` shadow the stdlib `typing`. This blocked user-facing acceptance of the whole `harp create project` cluster (#808/#809/#811/#812).

## Fix

Add a `harp` console entry point aliasing `harp-proxy`:

```toml
[project.scripts]
harp-proxy = "harp.commandline:entrypoint"
harp = "harp.commandline:entrypoint"
```

Console scripts run the entry point (never the directory), and `python -m harp` from the repo root keeps the repo root on `sys.path` — so no supported invocation puts `harp/` on the path, and the stdlib is never shadowed. This also aligns the CLI with the documented `harp create project` UX.

## Acceptance criteria

- [x] `python -m harp create project <name>` from a checkout no longer ImportErrors (imports cleanly, reaches the interactive prompt).
- [x] `uv run harp ...` works from the repo root.
- [x] CI exercises the CLI from the source checkout — `tests/test_cli_entrypoint.py` runs the `harp` console script and `python -m harp` (not `subprocess`-marked, so it runs in the E2E job). Verified red without the entry point (registration test fails, script tests skip).

## Deliberately out of scope → follow-up

The deeper landmine — `harp/typing/` sharing a name with the stdlib — is only reachable now via unsupported *directory* execution (`python harp/__main__.py`). Renaming `harp/typing` (~17 refs) is a **BC-touching** change I don't want to smuggle into a stop-the-line hotfix; I'll file it as a separate hardening issue. The AC's "or otherwise guarantee the CLI never puts `harp/` on sys.path" is met by this entry point.

Closes #825