### PR TITLE
fix(build): keep dashboard web/ dir on fresh checkouts so builds don't fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-!/harp_apps/dashboard/web/.gitkeep
 !/misc/cache-tests/cache-tests/results/index.mjs
 *$py.class
 *.cover
@@ -95,3 +94,12 @@ venv.bak/
 venv/
 web/
 wheels/
+
+# The dashboard web build output is git-ignored (it is produced by the frontend
+# build), but its directory is a hatchling force-include target: it must exist on
+# a fresh checkout or `uv sync` / the wheel build fails with FileNotFoundError.
+# Keep an empty .gitkeep so the directory always ships. These rules must stay
+# below the generic `web/` ignore above to take precedence over it.
+!/harp_apps/dashboard/web/
+/harp_apps/dashboard/web/*
+!/harp_apps/dashboard/web/.gitkeep

--- a/docs/changelogs/unreleased.rst
+++ b/docs/changelogs/unreleased.rst
@@ -12,3 +12,4 @@ Fixed
 
 - Replaced the dead GitLab CI/CD pipeline badge and stale "CI/CD" link in the README with the GitHub Actions workflow, aligning the public docs with where CI actually runs since 0.9.0
 - Restored the ``harp`` command as an alias of ``harp-proxy`` so ``harp ...`` and ``uv run harp ...`` run the CLI instead of executing the package directory (which shadowed the stdlib ``typing`` module and crashed from a source checkout); the documented ``harp create project`` flow now works.
+- Committed a ``.gitkeep`` in ``harp_apps/dashboard/web/`` so a fresh clone can ``uv sync`` and build the wheel; the directory is a hatchling force-include target and previously vanished on checkout (its ``.gitignore`` allow-rule was overridden by a later pattern), making the build fail with ``FileNotFoundError``.

--- a/tests/test_wheel_packaging.py
+++ b/tests/test_wheel_packaging.py
@@ -11,6 +11,8 @@ the real include/exclude rules from ``pyproject.toml`` without building a wheel
 """
 
 import re
+import subprocess
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -18,9 +20,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # Matches Python test code and dev-only testing utilities.
-TEST_FILE = re.compile(
-    r"(^|/)(tests|testing|__snapshots__)/|(^|/)conftest\.py$|(^|/)test_[^/]*\.py$|_test\.py$"
-)
+TEST_FILE = re.compile(r"(^|/)(tests|testing|__snapshots__)/|(^|/)conftest\.py$|(^|/)test_[^/]*\.py$|_test\.py$")
 
 # The cookiecutter templates ship as production scaffolding; their own tests/ and
 # conftest.py belong in the generated user project and must stay in the wheel.
@@ -41,11 +41,7 @@ def _wheel_distribution_paths():
 def test_wheel_excludes_python_test_code():
     """No test files or testing utilities leak into the wheel (cookiecutter templates aside)."""
     paths = _wheel_distribution_paths()
-    leaked = sorted(
-        p
-        for p in paths
-        if p.endswith(".py") and TEST_FILE.search(p) and not p.startswith(TEMPLATE_PREFIX)
-    )
+    leaked = sorted(p for p in paths if p.endswith(".py") and TEST_FILE.search(p) and not p.startswith(TEMPLATE_PREFIX))
     assert leaked == [], f"test code should not ship in the wheel: {leaked}"
 
 
@@ -63,3 +59,41 @@ def test_wheel_keeps_production_modules():
     paths = _wheel_distribution_paths()
     for module in ("harp/__init__.py", "harp/config/__init__.py", "harp_apps/proxy/__init__.py"):
         assert module in paths, f"production module missing from wheel: {module}"
+
+
+def _force_include_source_dirs():
+    """The force-include source directories declared for the sdist and wheel builds."""
+    if not (REPO_ROOT / "pyproject.toml").exists():
+        pytest.skip("not a source checkout")
+    config = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    targets = config["tool"]["hatch"]["build"]["targets"]
+    sources = set()
+    for target in targets.values():
+        sources.update(target.get("force-include", {}).keys())
+    return sorted(source for source in sources if (REPO_ROOT / source).is_dir())
+
+
+def _tracked_files(path: str):
+    """Files git tracks under ``path`` — what a fresh clone would actually check out."""
+    result = subprocess.run(
+        ["git", "ls-files", "--", path],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def test_force_include_sources_survive_a_fresh_checkout():
+    """Every force-include source must ship a tracked file, or a fresh clone can't build.
+
+    Hatchling resolves force-include paths at build time and raises FileNotFoundError
+    when a declared source directory is absent. A directory whose contents are all
+    git-ignored vanishes on a fresh checkout, so it must keep at least one tracked
+    file (e.g. a .gitkeep) to guarantee the build target always exists.
+    """
+    sources = _force_include_source_dirs()
+    assert sources, "expected at least one force-include source directory to guard"
+    missing = [source for source in sources if not _tracked_files(source)]
+    assert missing == [], f"force-include sources with no git-tracked file (break fresh clones): {missing}"


### PR DESCRIPTION
## What & why

`harp_apps/dashboard/web/` is a hatchling **force-include** target (declared for both the sdist and wheel builds), but its contents are entirely git-ignored and its `.gitkeep` was **never committed**. On a fresh clone the directory doesn't exist, so `uv sync` and the wheel build fail up front with `FileNotFoundError` — blocking any new contributor, and trapping existing envs the moment `web/` is removed (e.g. `git clean -fdx`), which then freezes the venv on stale code.

The `.gitignore` allow-rule for the keep file was also **dead**: it sat on line 1, but a later generic `web/` pattern excluded the parent directory, so git never descended into it to honour the negation.

## Changes

- Commit an empty `harp_apps/dashboard/web/.gitkeep` so the directory always ships.
- Fix `.gitignore`: move the allow-rule below the generic `web/` pattern and re-include the directory itself (`!.../web/` → `/.../web/*` → `!.../web/.gitkeep`), so only the keep file is tracked while the rest of the build output stays ignored.
- Add a guard test (`test_force_include_sources_survive_a_fresh_checkout`) that asserts every force-include source directory ships at least one git-tracked file, so this whole class of "fresh clone can't build" regression can't come back silently.

## Verification

- New test goes red on `main`/`0.10` and green with the fix (TDD).
- `tests/test_wheel_packaging.py`: 4/4 pass; the rest of `web/` (built assets) remains git-ignored.
- `ruff check` / `ruff format --check` clean.

Fixes #831