### PR TITLE
feat(create): CLI args and flags for 'harp create project'

### DIFF
--- a/docs/changelogs/unreleased.rst
+++ b/docs/changelogs/unreleased.rst
@@ -1,6 +1,11 @@
 Unreleased
 ==========
 
+Added
+:::::
+
+- ``harp create project`` now accepts the project name as an argument and ``--no-app`` / ``--no-config`` flags to skip the application folder or the config file, running without interactive prompts when the name and git author (from ``git config``) are available. New projects are created with an application folder by default.
+
 Changed
 :::::::
 

--- a/harp/commandline/cookiecutters/project/cookiecutter.json
+++ b/harp/commandline/cookiecutters/project/cookiecutter.json
@@ -4,7 +4,7 @@
   "__pkg_name": "{{cookiecutter.name | slugify(separator='_')}}",
   "author_name": "Smart Anonymous Harpist",
   "author_email": "anonymous@harp-proxy.net",
-  "create_application": false,
+  "create_application": true,
   "create_config": true,
   "__prompts__": {
     "name": "Project name (used to generate directory and package names)",

--- a/harp/commandline/create.py
+++ b/harp/commandline/create.py
@@ -1,6 +1,8 @@
+import json
 import os
 import shutil
 import subprocess
+import tempfile
 from typing import cast
 
 from click import BaseCommand
@@ -8,23 +10,70 @@ from click import BaseCommand
 from harp.commandline import cookiecutters as templates
 from harp.utils.commandline import click
 
+DEFAULT_AUTHOR_NAME = "Smart Anonymous Harpist"
+DEFAULT_AUTHOR_EMAIL = "anonymous@harp-proxy.net"
+
+
+def get_git_config(key):
+    """Return a git config value (e.g. ``user.name``), or None if unset or git is unavailable."""
+    try:
+        result = subprocess.run(["git", "config", key], capture_output=True, text=True)
+    except FileNotFoundError:
+        return None
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def _cookiecutter_command():
+    """Resolve how to run cookiecutter: the installed binary, or `uv tool run` as a fallback."""
+    if shutil.which("cookiecutter"):
+        return ["cookiecutter"]
+    if shutil.which("uv"):
+        return ["uv", "tool", "run", "cookiecutter"]
+    raise click.UsageError(
+        "Install cookiecutter with `uv add harp-proxy --extra dev`, or ensure `uv` is available to "
+        "run it via `uv tool run`."
+    )
+
 
 @click.command("create", short_help="Creates a templated directory using cookiecutter (project...).")
 @click.argument("template", type=click.Choice(["project"], case_sensitive=False))
-def create(template):
-    """Creates a new project using cookiecutter."""
+@click.argument("name", required=False)
+@click.option("--no-app", is_flag=True, help="Do not create an application folder for custom code.")
+@click.option("--no-config", is_flag=True, help="Do not create a config.yml file.")
+def create(template, name, no_app, no_config):
+    """Creates a new project using cookiecutter.
 
+    The project name can be passed as an argument to skip the interactive prompt; author
+    information is taken from your git config when available. Use --no-app / --no-config to
+    opt out of the application folder or the config file.
+    """
+
+    command = _cookiecutter_command()
     template_path = os.path.join(templates.__path__[0], template)
 
-    if shutil.which("cookiecutter"):
-        subprocess.run(["cookiecutter", template_path], check=True)
-    elif shutil.which("uv"):
-        subprocess.run(["uv", "tool", "run", "cookiecutter", template_path], check=True)
-    else:
-        raise click.UsageError(
-            "Install cookiecutter with `uv add harp-proxy --extra dev`, or ensure `uv` is available to "
-            "run it via `uv tool run`."
-        )
+    if not name:
+        name = click.prompt("Project name")
+    author_name = get_git_config("user.name") or click.prompt("Author name", default=DEFAULT_AUTHOR_NAME)
+    author_email = get_git_config("user.email") or click.prompt("Author email", default=DEFAULT_AUTHOR_EMAIL)
+
+    context = {
+        "name": name,
+        "author_name": author_name,
+        "author_email": author_email,
+        "create_application": not no_app,
+        "create_config": not no_config,
+    }
+
+    # cookiecutter runs as a subprocess (possibly in its own environment via `uv tool run`), so we
+    # cannot pass a Python context directly. A JSON config file is valid YAML, which lets cookiecutter
+    # read real booleans -- CLI `key=value` overrides would arrive as strings and break the template's
+    # boolean conditionals.
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        config_file = os.path.join(tmp_dir, "cookiecutter_config.json")
+        with open(config_file, "w") as fp:
+            json.dump({"default_context": context}, fp)
+
+        subprocess.run([*command, "--no-input", "--config-file", config_file, template_path], check=True)
 
 
 create = cast(BaseCommand, create)

--- a/harp/commandline/tests/test_create.py
+++ b/harp/commandline/tests/test_create.py
@@ -1,45 +1,107 @@
-"""Tests for the `harp create` command's cookiecutter invocation (subprocess, uv fallback)."""
+"""Tests for the `harp create` command (subprocess invocation, uv fallback, CLI-driven context)."""
 
-from unittest.mock import patch
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
 from harp.commandline.create import create
 
+WHICH_BOTH = {"cookiecutter": "/usr/bin/cookiecutter", "uv": "/usr/bin/uv"}
+GIT_AUTHOR = {"user.name": "Ada Lovelace", "user.email": "ada@example.com"}
 
-def _invoke(which_map):
-    """Invoke `create project` with shutil.which stubbed from which_map, capturing subprocess.run."""
+
+def _run(args, *, which=None, git=None, cli_input=None):
+    """Invoke `create` with `shutil.which`/`get_git_config` stubbed.
+
+    Captures the argv passed to cookiecutter and the JSON context written to the
+    `--config-file`, reading the file *during* the (mocked) subprocess call so it is
+    still on disk.
+    """
+    which = WHICH_BOTH if which is None else which
+    git = git or {}
+    captured = {}
+
+    def _capture(cmd, **kwargs):
+        captured["cmd"] = cmd
+        if "--config-file" in cmd:
+            config_path = cmd[cmd.index("--config-file") + 1]
+            captured["config"] = json.loads(Path(config_path).read_text())
+        return MagicMock(returncode=0)
+
     with (
-        patch("harp.commandline.create.shutil.which", side_effect=lambda name: which_map.get(name)),
-        patch("harp.commandline.create.subprocess.run") as run,
+        patch("harp.commandline.create.shutil.which", side_effect=lambda name: which.get(name)),
+        patch("harp.commandline.create.get_git_config", side_effect=lambda key: git.get(key)),
+        patch("harp.commandline.create.subprocess.run", side_effect=_capture) as run,
     ):
-        result = CliRunner().invoke(create, ["project"])
-    return result, run
+        result = CliRunner().invoke(create, ["project", *args], input=cli_input)
+    return result, run, captured
 
 
 class TestCreateCookiecutterInvocation:
     def test_runs_cookiecutter_binary_when_available(self):
-        result, run = _invoke({"cookiecutter": "/usr/bin/cookiecutter", "uv": "/usr/bin/uv"})
+        result, run, captured = _run(["my-proj"], git=GIT_AUTHOR)
         assert result.exit_code == 0, result.output
         run.assert_called_once()
-        args = run.call_args.args[0]
-        assert args[0] == "cookiecutter"
-        assert args[-1].endswith("project")
+        cmd = captured["cmd"]
+        assert cmd[0] == "cookiecutter"
+        assert "--no-input" in cmd
+        assert cmd[-1].endswith("project")
 
     def test_falls_back_to_uv_tool_run_when_cookiecutter_absent(self):
-        result, run = _invoke({"cookiecutter": None, "uv": "/usr/bin/uv"})
+        result, run, captured = _run(["my-proj"], which={"cookiecutter": None, "uv": "/usr/bin/uv"}, git=GIT_AUTHOR)
         assert result.exit_code == 0, result.output
-        run.assert_called_once()
-        args = run.call_args.args[0]
-        assert args[:4] == ["uv", "tool", "run", "cookiecutter"]
-        assert args[-1].endswith("project")
+        cmd = captured["cmd"]
+        assert cmd[:4] == ["uv", "tool", "run", "cookiecutter"]
+        assert cmd[-1].endswith("project")
 
     def test_errors_with_uv_message_when_nothing_available(self):
-        result, run = _invoke({"cookiecutter": None, "uv": None})
+        result, run, _ = _run(["my-proj"], which={"cookiecutter": None, "uv": None}, git=GIT_AUTHOR)
         assert result.exit_code != 0
         run.assert_not_called()
         assert "uv" in result.output.lower()
         assert "poetry" not in result.output.lower()
+
+
+class TestCreateProjectContext:
+    def test_name_argument_is_passed_as_context(self):
+        _, _, captured = _run(["my-proj"], git=GIT_AUTHOR)
+        assert captured["config"]["default_context"]["name"] == "my-proj"
+
+    def test_defaults_enable_application_and_config(self):
+        _, _, captured = _run(["my-proj"], git=GIT_AUTHOR)
+        context = captured["config"]["default_context"]
+        assert context["create_application"] is True
+        assert context["create_config"] is True
+
+    def test_no_app_flag_disables_application(self):
+        _, _, captured = _run(["my-proj", "--no-app"], git=GIT_AUTHOR)
+        assert captured["config"]["default_context"]["create_application"] is False
+
+    def test_no_config_flag_disables_config(self):
+        _, _, captured = _run(["my-proj", "--no-config"], git=GIT_AUTHOR)
+        assert captured["config"]["default_context"]["create_config"] is False
+
+    def test_author_is_read_from_git_config(self):
+        _, _, captured = _run(["my-proj"], git=GIT_AUTHOR)
+        context = captured["config"]["default_context"]
+        assert context["author_name"] == "Ada Lovelace"
+        assert context["author_email"] == "ada@example.com"
+
+    def test_always_runs_non_interactively(self):
+        _, _, captured = _run(["my-proj"], git=GIT_AUTHOR)
+        assert "--no-input" in captured["cmd"]
+
+    def test_prompts_for_name_when_missing(self):
+        _, _, captured = _run([], git=GIT_AUTHOR, cli_input="Prompted Name\n")
+        assert captured["config"]["default_context"]["name"] == "Prompted Name"
+
+    def test_prompts_for_author_when_git_config_absent(self):
+        _, _, captured = _run(["my-proj"], git={}, cli_input="Jane Doe\njane@doe.net\n")
+        context = captured["config"]["default_context"]
+        assert context["author_name"] == "Jane Doe"
+        assert context["author_email"] == "jane@doe.net"
 
 
 class TestDocsProcessCommand:

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -351,6 +351,11 @@ class TestCookiecutterPrompts:
             "Create config prompt should explain it creates an empty configuration file"
         )
 
+    def test_application_and_config_are_created_by_default(self, cookiecutter_json):
+        """Verify the template defaults create both the application folder and the config file."""
+        assert cookiecutter_json["create_application"] is True, "create_application should default to true"
+        assert cookiecutter_json["create_config"] is True, "create_config should default to true"
+
     def test_all_user_facing_variables_have_prompts(self, cookiecutter_json):
         """Verify all non-internal variables have custom prompts."""
         prompts = cookiecutter_json["__prompts__"]


### PR DESCRIPTION
Closes #809. Builds on the subprocess-based `create.py` from #824.

## What changes

`harp create project` gains a non-interactive UX:

```bash
harp create project my-project              # app + config, no prompts (author from git config)
harp create project my-project --no-app     # skip the application folder
harp create project my-project --no-config  # skip config.yml
```

- **Name** is a positional argument; prompted only when omitted.
- **Author** is read from `git config` (`user.name` / `user.email`); prompted only when git config is empty.
- **`--no-app` / `--no-config`** control the optional features; new projects include an application folder **by default** (`cookiecutter.json` default flipped `false` → `true`).

## The interesting bit

#824 moved cookiecutter to a subprocess invocation. Passing context as CLI `key=value` overrides makes every value a **string**, and a non-empty `"false"` is **truthy** in Jinja (`{% if cookiecutter.create_application %}`) and never matches the post-gen hook's `== "False"` check, so `--no-app` / `--no-config` would be silently ignored (confirmed empirically).

Instead of reworking the template's boolean contract (which a large, stable integration suite depends on), the command writes a temporary **JSON config file** and runs `cookiecutter --no-input --config-file …`. JSON is valid YAML, so cookiecutter reads **real booleans** and the existing template conditionals keep working untouched. Using stdlib `json` avoids depending on PyYAML being importable in the (possibly separate) cookiecutter environment.

## Tests

- `harp/commandline/tests/test_create.py`: name argument, `--no-app` / `--no-config`, default-on, git-config author, prompting fallbacks, and `--no-input` invocation (subprocess + written config asserted).
- `tests/test_cookiecutter_template.py`: pins the new create-application default.
- The cookiecutter template and its generation/hook integration tests are unchanged and stay green.

Verified end-to-end by generating real projects (default and `--no-app --no-config`) and checking the folder layout and Makefile server line.