### PR TITLE
docs: add Definition of Ready & Done, PR template and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Code owners for HARP.
+#
+# A pull request needs an approving review from a code owner before it can merge
+# (see DEFINITIONS.md, Definition of Done). Enforce it with branch protection:
+# require review from Code Owners on the default branch.
+#
+# Expand this list as the maintainer team grows (most specific match wins).
+
+*       @hartym

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## What & why
+
+<!-- What this changes and why. Link the issue, e.g. Closes #NNN -->
+
+## Definition of Done
+
+<!-- Tick each item, or strike it through with a one-line reason when it does not apply. -->
+
+- [ ] New or changed behaviour is covered by tests (codeless changes and well-covered refactors excepted, per code-owner judgment)
+- [ ] Full test suite green in CI on this head
+- [ ] Docs and changelog updated for behaviour / public-interface changes
+- [ ] Comprehensive automated review run; findings resolved or dismissed
+- [ ] Approving review from a code owner (ready to merge)
+- [ ] Manual verification done only after CI is green; behaviour confirmed end-to-end, worthwhile checks captured as tests
+- [ ] All acceptance criteria on the issue are met
+
+<!-- Full checklists: see DEFINITIONS.md (Definition of Ready & Definition of Done). -->

--- a/DEFINITIONS.md
+++ b/DEFINITIONS.md
@@ -1,0 +1,32 @@
+# Definition of Ready & Definition of Done
+
+Two short checklists that keep HARP's flow honest: an issue must be **Ready** before work
+starts, and a pull request must be **Done** before it merges. Every line is meant to be
+checked, not admired. Keep it lightweight; when a line genuinely does not apply, say why.
+
+## Definition of Ready (DoR)
+
+An issue is ready to be picked up when:
+
+- **Why is clear**: the problem and the expected outcome are stated; out of scope is bounded.
+- **Shaped as a story**: role, action, result; small enough to ship in one iteration (split if not).
+- **Acceptance criteria**: 3 to 5 verifiable criteria, including at least one negative / regression case.
+- **Dependencies resolved**: design, API, docs and blocking issues are settled within reach.
+- **Approach agreed**: for anything non-trivial, the technical direction is confirmed by a maintainer.
+- **Estimated**: coarsely sized.
+
+## Definition of Done (DoD)
+
+A pull request is done when every applicable item is verified. Each PR restates this as a
+checklist (see [`.github/pull_request_template.md`](.github/pull_request_template.md)):
+
+- **Automated tests** cover new or changed behaviour. No new tests are expected for codeless changes (documentation, CI / tooling) or for refactors already protected by adequate existing coverage: the code owner judges what is adequate, case by case. No tests written just to tick a box.
+- **Tests pass at all times**: the full suite is green in CI on the PR head; nothing merges red.
+- **Docs checked**: behaviour or public-interface changes update the docs and the changelog in the same PR.
+- **Comprehensive review**: an automated, in-depth review has been run and its findings resolved or explicitly dismissed.
+- **Code review approved**: at least one code owner has an approving review on GitHub (marked ready to merge).
+- **Manual verification**: begins only once CI is fully green on the PR head, then confirms the behaviour end-to-end; the reviewer decides which manual checks are worth locking in as automated tests.
+- **Acceptance criteria met**: every criterion on the issue is satisfied.
+
+Code owners (whose review gates a merge) are listed in
+[`.github/CODEOWNERS`](.github/CODEOWNERS).


### PR DESCRIPTION
## What & why

Adds lightweight, verifiable checklists so contributions share one bar:

- `DEFINITIONS.md`: Definition of Ready (an issue can be picked up) and Definition of Done (a PR can merge). Short, one bullet per thing to verify.
- `.github/pull_request_template.md`: the DoD as a per-PR checklist, so each PR restates it.
- `.github/CODEOWNERS`: code owners whose review gates a merge (starter list, expand as the team grows).

To make the "code owner approval" and "tests green" lines actually binding, enable branch protection on the default branch (require review from Code Owners, require status checks).

## Definition of Done

- [x] Codeless change (docs and tooling config): no automated tests needed
- [x] No behaviour or public-interface code changed; nothing to document beyond these files
- [ ] Approving review from a code owner (ready to merge)