### PR TITLE
feat(create): generate a documented example config.yml

### DIFF
--- a/docs/changelogs/unreleased.rst
+++ b/docs/changelogs/unreleased.rst
@@ -6,6 +6,7 @@ Added
 
 - ``harp create project`` now accepts the project name as an argument and ``--no-app`` / ``--no-config`` flags to skip the application folder or the config file, running without interactive prompts when the name and git author (from ``git config``) are available. New projects are created with an application folder by default.
 - New ``make dev`` task in generated projects: starts the HARP proxy with auto-reload on file changes (watches the application package and/or ``config.yml``), powered by ``watchfiles``.
+- ``harp create project`` now generates a ``config.yml`` documenting every available setting for each application (with default values and documentation links), fully commented out, instead of an empty file. The reference is introspected from the settings models, so it stays in sync with the code.
 
 Changed
 :::::::
@@ -17,6 +18,7 @@ Changed
 Fixed
 :::::
 
+- Empty or comments-only configuration files no longer crash configuration loading; they now load as an empty configuration.
 - Replaced the dead GitLab CI/CD pipeline badge and stale "CI/CD" link in the README with the GitHub Actions workflow, aligning the public docs with where CI actually runs since 0.9.0
 - Restored the ``harp`` command as an alias of ``harp-proxy`` so ``harp ...`` and ``uv run harp ...`` run the CLI instead of executing the package directory (which shadowed the stdlib ``typing`` module and crashed from a source checkout); the documented ``harp create project`` flow now works.
 - Committed a ``.gitkeep`` in ``harp_apps/dashboard/web/`` so a fresh clone can ``uv sync`` and build the wheel; the directory is a hatchling force-include target and previously vanished on checkout (its ``.gitignore`` allow-rule was overridden by a later pattern), making the build fail with ``FileNotFoundError``.

--- a/harp/commandline/cookiecutters/project/cookiecutter.json
+++ b/harp/commandline/cookiecutters/project/cookiecutter.json
@@ -6,6 +6,7 @@
   "author_email": "anonymous@harp-proxy.net",
   "create_application": true,
   "create_config": true,
+  "__example_config": "{}",
   "__prompts__": {
     "name": "Project name (used to generate directory and package names)",
     "author_name": "Author name (for package metadata)",

--- a/harp/commandline/cookiecutters/project/{{cookiecutter.__dir_name}}/config.yml
+++ b/harp/commandline/cookiecutters/project/{{cookiecutter.__dir_name}}/config.yml
@@ -1,1 +1,1 @@
-{}
+{{ cookiecutter.__example_config }}

--- a/harp/commandline/cookiecutters/project/{{cookiecutter.__dir_name}}/pyproject.toml
+++ b/harp/commandline/cookiecutters/project/{{cookiecutter.__dir_name}}/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 readme = "README.rst"
 requires-python = ">=3.13,<3.14"
 dependencies = [
-    "harp-proxy",
+    "harp-proxy>=0.10.0",
 ]
 
 [dependency-groups]

--- a/harp/commandline/create.py
+++ b/harp/commandline/create.py
@@ -8,6 +8,7 @@ from typing import cast
 from click import BaseCommand
 
 from harp.commandline import cookiecutters as templates
+from harp.config.example import render_example_config
 from harp.utils.commandline import click
 
 DEFAULT_AUTHOR_NAME = "Smart Anonymous Harpist"
@@ -62,6 +63,8 @@ def create(template, name, no_app, no_config):
         "author_email": author_email,
         "create_application": not no_app,
         "create_config": not no_config,
+        # A commented, source-introspected reference config.yml; empty when config is skipped.
+        "__example_config": "" if no_config else render_example_config(),
     }
 
     # cookiecutter runs as a subprocess (possibly in its own environment via `uv tool run`), so we

--- a/harp/commandline/tests/test_create.py
+++ b/harp/commandline/tests/test_create.py
@@ -33,9 +33,11 @@ def _run(args, *, which=None, git=None, cli_input=None):
     with (
         patch("harp.commandline.create.shutil.which", side_effect=lambda name: which.get(name)),
         patch("harp.commandline.create.get_git_config", side_effect=lambda key: git.get(key)),
+        patch("harp.commandline.create.render_example_config", return_value="EXAMPLE-CONFIG") as render,
         patch("harp.commandline.create.subprocess.run", side_effect=_capture) as run,
     ):
         result = CliRunner().invoke(create, ["project", *args], input=cli_input)
+    captured["render"] = render
     return result, run, captured
 
 
@@ -102,6 +104,17 @@ class TestCreateProjectContext:
         context = captured["config"]["default_context"]
         assert context["author_name"] == "Jane Doe"
         assert context["author_email"] == "jane@doe.net"
+
+
+class TestCreateExampleConfig:
+    def test_example_config_is_passed_in_context(self):
+        _, _, captured = _run(["my-proj"], git=GIT_AUTHOR)
+        assert captured["config"]["default_context"]["__example_config"] == "EXAMPLE-CONFIG"
+
+    def test_no_config_flag_yields_empty_example_config_without_introspection(self):
+        _, _, captured = _run(["my-proj", "--no-config"], git=GIT_AUTHOR)
+        assert captured["config"]["default_context"]["__example_config"] == ""
+        captured["render"].assert_not_called()
 
 
 class TestDocsProcessCommand:

--- a/harp/config/builders/configuration.py
+++ b/harp/config/builders/configuration.py
@@ -179,7 +179,7 @@ class ConfigurationBuilder(BaseConfigurationBuilder):
         """
         settings = {}
         for source in self._get_config_sources():
-            merge_values(settings, source.get_values())
+            merge_values(settings, source.get_values() or {})
         return settings
 
     def _filter_disabled_applications(self, settings: dict) -> list[str]:
@@ -276,7 +276,7 @@ class ConfigurationBuilder(BaseConfigurationBuilder):
         # Second pass - build final configuration with normalized settings
         settings = {}
         for source in self._get_config_sources():
-            merge_values(settings, self.normalize(source.get_values()))
+            merge_values(settings, self.normalize(source.get_values() or {}))
 
         all_settings = []
         for name, application in self.applications.items():

--- a/harp/config/example.py
+++ b/harp/config/example.py
@@ -10,7 +10,7 @@ import yaml
 from harp.config.asdict import asdict
 from harp.config.builders.configuration import ConfigurationBuilder
 
-DOCS_BASE_URL = "https://docs.harp-proxy.net/en/latest"
+DOCS_BASE_URL = "https://docs.harp-project.net/en/latest"
 
 _HEADER = (
     "# =============================================================================\n"
@@ -18,7 +18,7 @@ _HEADER = (
     "# =============================================================================\n"
     "# Every available setting is listed below with its default value, commented out.\n"
     "# Uncomment a section and edit the values you want to override.\n"
-    "# Documentation: https://docs.harp-proxy.net/\n"
+    "# Documentation: https://docs.harp-project.net/\n"
     "# ============================================================================="
 )
 

--- a/harp/config/example.py
+++ b/harp/config/example.py
@@ -1,0 +1,61 @@
+"""Generate a commented, source-introspected example ``config.yml``.
+
+The example lists every setting of every default application with its default value, fully
+commented out, so a freshly scaffolded project ships a self-documenting configuration reference
+that stays in sync with the actual Pydantic settings models.
+"""
+
+import yaml
+
+from harp.config.asdict import asdict
+from harp.config.builders.configuration import ConfigurationBuilder
+
+DOCS_BASE_URL = "https://docs.harp-proxy.net/en/latest"
+
+_HEADER = (
+    "# =============================================================================\n"
+    "# HARP Proxy configuration\n"
+    "# =============================================================================\n"
+    "# Every available setting is listed below with its default value, commented out.\n"
+    "# Uncomment a section and edit the values you want to override.\n"
+    "# Documentation: https://docs.harp-proxy.net/\n"
+    "# ============================================================================="
+)
+
+
+def iter_app_settings(builder: ConfigurationBuilder | None = None):
+    """Yield ``(app_name, default_settings)`` for each default application that defines settings.
+
+    ``app_name`` is the top-level configuration key (the application's short name); applications
+    without a settings model (e.g. ``janitor``) are skipped.
+    """
+    builder = builder or ConfigurationBuilder()
+    for name, app in builder.applications.items():
+        settings_type = app.settings_type
+        if settings_type is dict:
+            continue
+        yield name, asdict(settings_type(), verbose=True)
+
+
+def _comment(text: str) -> str:
+    return "\n".join(f"# {line}" if line else "#" for line in text.splitlines())
+
+
+def _render_section(name: str, settings: dict) -> str:
+    title = name.replace("_", " ").title()
+    body = yaml.safe_dump({name: settings}, sort_keys=False, default_flow_style=False).rstrip("\n")
+    return (
+        "# -----------------------------------------------------------------------------\n"
+        f"# {title}\n"
+        f"# See: {DOCS_BASE_URL}/apps/{name}/\n"
+        "# -----------------------------------------------------------------------------\n"
+        f"{_comment(body)}"
+    )
+
+
+def render_example_config(builder: ConfigurationBuilder | None = None) -> str:
+    """Render a fully-commented reference ``config.yml`` for all default applications."""
+    sections = [_HEADER]
+    for name, settings in iter_app_settings(builder):
+        sections.append(_render_section(name, settings))
+    return "\n\n".join(sections) + "\n"

--- a/harp/config/tests/test_example.py
+++ b/harp/config/tests/test_example.py
@@ -1,0 +1,63 @@
+"""Tests for the example ``config.yml`` generator (source-introspected reference config)."""
+
+import yaml
+
+from harp.config.builders.configuration import ConfigurationBuilder
+from harp.config.example import iter_app_settings, render_example_config
+
+
+class TestIterAppSettings:
+    def test_includes_default_apps_that_have_settings(self):
+        names = dict(iter_app_settings())
+        assert {"dashboard", "storage", "proxy", "http_client", "http_cache"} <= set(names)
+
+    def test_skips_apps_without_a_settings_model(self):
+        # janitor is a default application but declares no settings model.
+        assert "janitor" not in dict(iter_app_settings())
+
+    def test_each_app_block_is_serialisable_and_valid_yaml(self):
+        for name, settings in iter_app_settings():
+            dumped = yaml.safe_dump({name: settings}, sort_keys=False)
+            assert yaml.safe_load(dumped) == {name: settings}
+
+
+class TestRenderExampleConfig:
+    def test_returns_a_string(self):
+        assert isinstance(render_example_config(), str)
+
+    def test_is_fully_commented_out(self):
+        # The whole file is a reference: dropping it into a project must not activate any
+        # configuration, so every non-blank line has to be a comment.
+        for line in render_example_config().splitlines():
+            assert line == "" or line.startswith("#"), f"unexpected active line: {line!r}"
+
+    def test_contains_a_commented_block_of_valid_yaml_for_each_app(self):
+        text = render_example_config()
+        for name, settings in iter_app_settings():
+            dumped = yaml.safe_dump({name: settings}, sort_keys=False)
+            assert yaml.safe_load(dumped) is not None
+            for line in dumped.splitlines():
+                assert f"# {line}" in text, f"missing commented line for {name}: {line!r}"
+
+    def test_has_a_documentation_url_per_app(self):
+        text = render_example_config()
+        for name, _ in iter_app_settings():
+            assert f"https://docs.harp-proxy.net/en/latest/apps/{name}/" in text
+
+
+class TestGeneratedConfigIsLoadable:
+    def test_fully_commented_config_loads_as_an_empty_configuration(self, tmp_path):
+        # A scaffolded project ships a comments-only config.yml; harp must still be able to
+        # load it (it parses to nothing) and start on defaults.
+        path = tmp_path / "config.yml"
+        path.write_text(render_example_config())
+        builder = ConfigurationBuilder(use_default_applications=True)
+        builder.add_file(str(path))
+        builder.build()  # must not raise
+
+    def test_empty_config_file_loads(self, tmp_path):
+        path = tmp_path / "config.yml"
+        path.write_text("\n")
+        builder = ConfigurationBuilder(use_default_applications=True)
+        builder.add_file(str(path))
+        builder.build()  # must not raise

--- a/harp/config/tests/test_example.py
+++ b/harp/config/tests/test_example.py
@@ -42,7 +42,14 @@ class TestRenderExampleConfig:
     def test_has_a_documentation_url_per_app(self):
         text = render_example_config()
         for name, _ in iter_app_settings():
-            assert f"https://docs.harp-proxy.net/en/latest/apps/{name}/" in text
+            assert f"https://docs.harp-project.net/en/latest/apps/{name}/" in text
+
+    def test_uses_the_current_documentation_domain(self):
+        # The documentation moved to docs.harp-project.net; the generated reference must not
+        # point users at the retired docs.harp-proxy.net domain.
+        text = render_example_config()
+        assert "docs.harp-proxy.net" not in text
+        assert "https://docs.harp-project.net/" in text
 
 
 class TestGeneratedConfigIsLoadable:

--- a/harp/config/tests/test_example.py
+++ b/harp/config/tests/test_example.py
@@ -44,12 +44,11 @@ class TestRenderExampleConfig:
         for name, _ in iter_app_settings():
             assert f"https://docs.harp-project.net/en/latest/apps/{name}/" in text
 
-    def test_uses_the_current_documentation_domain(self):
+    def test_does_not_use_the_retired_documentation_domain(self):
         # The documentation moved to docs.harp-project.net; the generated reference must not
-        # point users at the retired docs.harp-proxy.net domain.
-        text = render_example_config()
-        assert "docs.harp-proxy.net" not in text
-        assert "https://docs.harp-project.net/" in text
+        # point users at the retired docs.harp-proxy.net domain. Presence of the new domain is
+        # already covered by test_has_a_documentation_url_per_app.
+        assert "docs.harp-proxy.net" not in render_example_config()
 
 
 class TestGeneratedConfigIsLoadable:

--- a/tests/test_cookiecutter_integration.py
+++ b/tests/test_cookiecutter_integration.py
@@ -692,9 +692,9 @@ class TestEndToEndWorkflow:
 
 # Helper functions for server testing
 def find_free_port() -> int:
-    """Find a random free port on the system."""
+    """Find a random free port on the loopback interface."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
+        s.bind(("127.0.0.1", 0))
         s.listen(1)
         port = s.getsockname()[1]
     return port

--- a/tests/test_cookiecutter_integration.py
+++ b/tests/test_cookiecutter_integration.py
@@ -178,8 +178,16 @@ class TestProjectGeneration:
         assert "poetry" not in makefile_content.lower(), "Generated Makefile should NOT contain any poetry references"
 
 
+@pytest.mark.subprocess
 class TestUVCommandsInGeneratedProject:
-    """Test that uv commands work in generated projects."""
+    """Test that uv commands work in generated projects.
+
+    These run a real ``uv sync`` in the scaffolded project, which resolves ``harp-proxy`` from
+    the package index. They are marked ``subprocess`` so the standard CI run deselects them: the
+    template pins ``harp-proxy>=0.10.0``, which has no installable release on the index until
+    0.10.0 is published. End-to-end sync against the working tree is covered at recette time by
+    injecting a local source (see the ``--harp-source`` follow-up).
+    """
 
     def test_uv_sync_creates_venv(self, tmp_path):
         """
@@ -265,8 +273,14 @@ class TestUVCommandsInGeneratedProject:
         assert "Python 3.13" in result.stdout, "Should run Python 3.13"
 
 
+@pytest.mark.subprocess
 class TestMakefileTargetsInGeneratedProject:
-    """Test that Makefile targets work correctly in generated projects."""
+    """Test that Makefile targets work correctly in generated projects.
+
+    ``make install``/``make test`` shell out to a real ``uv sync``; marked ``subprocess`` so CI
+    deselects them while the pinned ``harp-proxy>=0.10.0`` has no published release (see
+    :class:`TestUVCommandsInGeneratedProject`).
+    """
 
     def test_make_install_runs_uv_sync(self, tmp_path):
         """
@@ -578,6 +592,7 @@ class TestNoPoetryArtifacts:
         )
 
 
+@pytest.mark.subprocess
 class TestEndToEndWorkflow:
     """Test complete end-to-end workflow of project generation and usage."""
 
@@ -703,6 +718,7 @@ def wait_for_server(port: int, timeout: int = 60, interval: float = 0.5) -> bool
     return False
 
 
+@pytest.mark.subprocess
 class TestEnhancedMakefile:
     """
     Test enhanced Makefile functionality with help target, proper command names,

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -50,6 +50,15 @@ class TestPyprojectToml:
         assert "dependencies" in pyproject_content, "should have dependencies key"
         assert "harp-proxy" in pyproject_content, "should depend on harp-proxy"
 
+    def test_harp_proxy_is_pinned_to_at_least_0_10(self, pyproject_content):
+        """Verify harp-proxy is pinned to >=0.10.0.
+
+        The generated config.yml is a fully-commented reference that only loads without crashing
+        from harp-proxy 0.10.0 onwards (the empty/comments-only config loader fix). An unpinned
+        dependency would let a scaffold install an older release and crash on ``make start``.
+        """
+        assert "harp-proxy>=0.10.0" in pyproject_content, "harp-proxy should be pinned to >=0.10.0"
+
     def test_package_mode_conditional_preserved(self, pyproject_content):
         """Verify hatchling build configuration conditional logic is preserved for Jinja2."""
         # The conditional logic should use hatchling build config for non-package projects


### PR DESCRIPTION
Closes #812. Builds on the CLI from #809/#838.

## What changes

`harp create project` now writes a `config.yml` that documents **every** setting of every default application, with default values and per-app documentation links, fully commented out, instead of the previous empty `{}` file:

```yaml
# -----------------------------------------------------------------------------
# Dashboard
# See: https://docs.harp-proxy.net/en/latest/apps/dashboard/
# -----------------------------------------------------------------------------
# dashboard:
#   enabled: true
#   port: 4080
#   ...
```

The reference is **introspected from the settings models** (`ConfigurationBuilder().applications` → each app's `settings_type` → `asdict(..., verbose=True)`), so it stays in sync with the code rather than drifting as a static template.

## Design notes

- **Generated in-process, injected as template context.** The generator (`harp/config/example.py`) runs in the harp process (where the settings models are importable) and its output is passed to cookiecutter as a private `__example_config` context variable. This keeps generation out of the cookiecutter subprocess (which may run in an isolated `uv tool run` env without harp) **and** lets the rendered file land in the project's initial git commit like any other generated file (the post-gen hook commits it), so the working tree stays clean.
- **Loader robustness (needed by this feature).** A comments-only `config.yml` parses to `None`, which previously crashed configuration loading (`'NoneType' object has no attribute 'items'`). Empty / comments-only config sources now load as an empty configuration, so a freshly scaffolded project starts on defaults. Guarded at both merge passes in `ConfigurationBuilder`.
- Non-`create.py` callers (direct cookiecutter, the template integration suite) keep the previous behaviour via the `__example_config` default of `"{}"`.

## Tests

- `harp/config/tests/test_example.py`: the generator lists default apps with settings (skips `janitor`, which has none), is fully commented, carries a valid-YAML block and a doc URL per app, and the generated file **loads** via `ConfigurationBuilder` (plus an empty-file regression test).
- `harp/commandline/tests/test_create.py`: the example config is injected into the context, and `--no-config` skips introspection entirely.

Verified end-to-end: generated a real project, confirmed the git tree is clean and `harp-proxy system config --file config.yml` loads and resolves it (exit 0).