### PR TITLE
refactor: 0.10 release code simplification review

### DIFF
--- a/bin/check_apps_dependencies.py
+++ b/bin/check_apps_dependencies.py
@@ -150,7 +150,7 @@ def analyze_app(app_dir: Path) -> DependencyAnalysis:
     )
 
 
-def print_report(analyses: list[DependencyAnalysis]) -> None:
+def print_report(analyses: list[DependencyAnalysis]) -> int:
     """Print a formatted report of dependency analysis."""
     print("=" * 80)
     print("HARP Application Dependency Analysis")

--- a/harp/commandline/utils/manager.py
+++ b/harp/commandline/utils/manager.py
@@ -8,6 +8,7 @@ import rich_click as click
 
 from harp import ROOT_DIR, get_logger
 from harp.utils.network import get_available_network_port
+from harp.utils.packages import import_string
 
 HARP_DASHBOARD_SERVICE = "harp:dashboard"
 HARP_DOCS_SERVICE = "harp:docs"
@@ -158,7 +159,7 @@ def parse_server_subprocesses_options(server_subprocesses):
 def get_honcho_manager_factory_type():
     edition = os.environ.get("HARP_EDITION", "harp_apps")
     try:
-        HonchoManagerFactoryType = __import__(edition, fromlist=["HonchoManagerFactory"]).HonchoManagerFactory
+        HonchoManagerFactoryType = import_string(f"{edition}.HonchoManagerFactory")
     except (ImportError, AttributeError):
         return HonchoManagerFactory
     return HonchoManagerFactoryType

--- a/harp/config/applications.py
+++ b/harp/config/applications.py
@@ -300,24 +300,21 @@ class ApplicationsRegistry:
         """Reorder applications based on dependency order using topological sort."""
         from harp.errors import MissingDependencyError
 
-        # Build dependency graph
+        # Build dependency graph and per-app in-degree (number of declared dependencies)
         graph = {}
         in_degree = {}
         original_order = list(self._applications.keys())
 
         for app_name in self._applications:
-            graph[app_name] = getattr(self._applications[app_name], "dependencies", [])
-            in_degree[app_name] = 0
+            dependencies = getattr(self._applications[app_name], "dependencies", [])
+            graph[app_name] = dependencies
+            in_degree[app_name] = len(dependencies)
 
         # Check for missing dependencies
         for app_name in self._applications:
             for dep in graph[app_name]:
                 if dep not in graph:
                     raise MissingDependencyError(f"Application '{app_name}' requires '{dep}' but it is not enabled")
-
-        # Calculate in-degree (number of declared dependencies per app)
-        for app_name in self._applications:
-            in_degree[app_name] = len(graph[app_name])
 
         # Detect cycles
         self._detect_dependency_cycles(graph)

--- a/harp/config/builders/configuration.py
+++ b/harp/config/builders/configuration.py
@@ -333,16 +333,8 @@ class ConfigurationBuilder(BaseConfigurationBuilder):
         """
         # todo: config instead of sources in constructor ? for example no_default_apps, etc.
 
-        try:
-            applications = options.applications
-        except AttributeError:
-            applications = None
-
-        # Get strict flag if available
-        try:
-            strict = options.strict
-        except AttributeError:
-            strict = False
+        applications = getattr(options, "applications", None)
+        strict = getattr(options, "strict", False)
 
         builder = cls(
             {"applications": applications} if applications else None,

--- a/harp/config/utils.py
+++ b/harp/config/utils.py
@@ -1,10 +1,12 @@
 import os
 
+from harp.utils.packages import import_string
+
 
 def get_configuration_builder_type():
     edition = os.environ.get("HARP_EDITION", "harp_apps")
     try:
-        ConfigurationBuilder = __import__(edition, fromlist=["ConfigurationBuilder"]).ConfigurationBuilder
+        ConfigurationBuilder = import_string(f"{edition}.ConfigurationBuilder")
     except (ImportError, AttributeError):
         from harp.config import ConfigurationBuilder
     return ConfigurationBuilder

--- a/harp/models/transactions.py
+++ b/harp/models/transactions.py
@@ -6,6 +6,14 @@ from .base import Entity
 from .messages import Message
 
 
+def encode_cache_flag(cached) -> str | None:
+    """Encode a transaction cache-hit flag for the ``x_cached`` storage column.
+
+    A truthy flag (an ``X-Cache: HIT``) is stored as the string ``"true"``; anything else as ``None``.
+    """
+    return "true" if cached else None
+
+
 @dataclasses.dataclass(kw_only=True)
 class Transaction(Entity):
     id: str = None
@@ -54,9 +62,7 @@ class Transaction(Entity):
 
         extras = data.pop("extras", {})
 
-        # Cache status is now a boolean (True) or None, based on X-Cache: HIT header
-        cached = extras.get("cached")
-        data["x_cached"] = "true" if cached else None
+        data["x_cached"] = encode_cache_flag(extras.get("cached"))
         data["x_method"] = extras.get("method")
         data["x_no_cache"] = bool(extras.get("no_cache"))
         data["x_status_class"] = extras.get("status_class")

--- a/harp_apps/dashboard/controllers/overview.py
+++ b/harp_apps/dashboard/controllers/overview.py
@@ -2,7 +2,6 @@ from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from statistics import StatisticsError, mean
 
-from harp import get_logger
 from harp.controllers import GetHandler, RouterPrefix, RoutingController
 from harp.http import HttpRequest
 from harp.views import json
@@ -10,8 +9,6 @@ from harp_apps.storage.constants import TimeBucket
 from harp_apps.storage.types import IStorage
 
 from ..utils.dates import generate_continuous_time_range, get_start_datetime_from_range
-
-logger = get_logger(__name__)
 
 time_bucket_for_range = {
     "1h": TimeBucket.HOUR.value,
@@ -106,23 +103,10 @@ class OverviewController(RoutingController):
         time_bucket = time_bucket_for_range.get(range, "day")
         start_datetime = get_start_datetime_from_range(range)
 
-        logger.debug(
-            f"🛑 {type(self).__name__}::get_overview_data 1️⃣ ",
-            endpoint=endpoint,
-            range=range,
-            time_bucket=time_bucket,
-            start_datetime=start_datetime,
-        )
-
         transactions_by_date_list = await self.storage.transactions_grouped_by_time_bucket(
             endpoint=endpoint,
             start_datetime=start_datetime,
             time_bucket=time_bucket,
-        )
-
-        logger.debug(
-            f"🛑 {type(self).__name__}::get_overview_data 2️⃣ ",
-            transactions_by_date_list=transactions_by_date_list,
         )
 
         errors_count = sum([t["errors"] for t in transactions_by_date_list])
@@ -139,11 +123,6 @@ class OverviewController(RoutingController):
             start_datetime=start_datetime,
         )
 
-        logger.debug(
-            f"🛑 {type(self).__name__}::get_overview_data 3️⃣ ",
-            transactions_by_date_list=transactions_by_date_list,
-        )
-
         mean_tpdex = _calculate_mean_tpdex(transactions_by_date_list)
 
         result = {
@@ -154,11 +133,6 @@ class OverviewController(RoutingController):
             "meanTpdex": mean_tpdex,
             "timeRange": range,
         }
-
-        logger.debug(
-            f"🛑 {type(self).__name__}::get_overview_data 4️⃣ ",
-            result=result,
-        )
 
         return json(result)
 

--- a/harp_apps/dashboard/utils/dates.py
+++ b/harp_apps/dashboard/utils/dates.py
@@ -62,19 +62,18 @@ def generate_continuous_time_range(
     datetime_range = [start_datetime + i * delta for i in range(int((end_datetime - start_datetime) / delta) + 1)]
 
     # Fill missing data points
-    continuous_transactions = []
-    for t in datetime_range:
-        if t in [d["datetime"] for d in discontinuous_transactions]:
-            continuous_transactions.append([d for d in discontinuous_transactions if d["datetime"] == t][0])
-        else:
-            continuous_transactions.append(
-                {
-                    "datetime": t,
-                    "count": None,
-                    "errors": None,
-                    "cached": 0,
-                    "meanDuration": None,
-                    "meanTpdex": None,
-                }
-            )
-    return continuous_transactions
+    transactions_by_datetime = {d["datetime"]: d for d in discontinuous_transactions}
+    return [
+        transactions_by_datetime.get(
+            t,
+            {
+                "datetime": t,
+                "count": None,
+                "errors": None,
+                "cached": 0,
+                "meanDuration": None,
+                "meanTpdex": None,
+            },
+        )
+        for t in datetime_range
+    ]

--- a/harp_apps/http_cache/adapters.py
+++ b/harp_apps/http_cache/adapters.py
@@ -35,12 +35,6 @@ class SerializedResponse(tp.TypedDict):
     extensions: dict[str, str]
 
 
-def _ensure_datestring(date: datetime | str):
-    if isinstance(date, datetime):
-        date = date.strftime("%a, %d %b %Y %H:%M:%S GMT")
-    return date
-
-
 class AsyncStorageAdapter:
     """Adapter that serializes/deserializes Entry objects to/from HARP blob storage.
 
@@ -124,8 +118,7 @@ class AsyncStorageAdapter:
 
     async def _decode(self, cached):
         """Decode cached blob data into structured format."""
-        data = yaml.safe_load(cached.data.decode())
-        return data
+        return yaml.safe_load(cached.data.decode())
 
     async def _store_entry_blob(
         self,

--- a/harp_apps/http_cache/utils.py
+++ b/harp_apps/http_cache/utils.py
@@ -1,7 +1,7 @@
 from hishel import Headers
 from multidict import CIMultiDict
 
-from harp.utils.bytes import ensure_str
+from harp.utils.bytes import ensure_bytes, ensure_str
 
 
 def prepare_headers_for_serialization(headers, /, *, varying=()) -> tuple[bytes, dict[str, str], dict[str, str]]:
@@ -24,7 +24,7 @@ def prepare_headers_for_serialization(headers, /, *, varying=()) -> tuple[bytes,
         # hishel 1.0: Headers is a MutableMapping
         header_items = [
             (
-                k.encode() if isinstance(k, str) else k,
+                ensure_bytes(k),
                 str(v).encode() if not isinstance(v, bytes) else v,
             )
             for k, v in headers.items()

--- a/harp_apps/http_client/events.py
+++ b/harp_apps/http_client/events.py
@@ -4,6 +4,7 @@ from httpx import Request, Response
 from whistle import Event
 
 from harp import get_logger
+from harp.utils.types import typeof
 
 logger = get_logger(__name__)
 
@@ -29,9 +30,7 @@ class HttpClientFilterEvent(Event):
 
     def set_response(self, response: Response):
         if response is not None and not isinstance(response, Response):
-            raise ValueError(
-                f"Response must be an instance of httpx.Response, got {response!r} ({type(response).__module__}.{type(response).__qualname__})."
-            )
+            raise ValueError(f"Response must be an instance of httpx.Response, got {response!r} ({typeof(response)}).")
         self.response = response
 
     @property
@@ -68,7 +67,7 @@ class HttpClientFilterEvent(Event):
             if context["response"] is not None:
                 if not isinstance(context["response"], Response):
                     raise ValueError(
-                        f"Response must be an instance of httpx.Response, got {context['response']!r} ({type(context['response']).__module__}.{type(context['response']).__qualname__})."
+                        f"Response must be an instance of httpx.Response, got {context['response']!r} ({typeof(context['response'])})."
                     )
             self.set_response(context["response"])
         return context

--- a/harp_apps/http_client/settings.py
+++ b/harp_apps/http_client/settings.py
@@ -1,11 +1,6 @@
 from pydantic import Field
-from typing import TYPE_CHECKING
 
 from harp.config import ApplicationSettingsMixin, Service
-
-if TYPE_CHECKING:
-    pass
-
 from harp.settings import DEFAULT_TIMEOUT
 
 

--- a/harp_apps/janitor/worker.py
+++ b/harp_apps/janitor/worker.py
@@ -100,9 +100,6 @@ class JanitorWorker:
         if count is None:
             # The blob storage may need to clean orphans but no implementation is available
             logger.debug("🧹 DeleteOrphanBlobs[%s] Not implemented.", self.blob_storage.type)
-        elif count is False:
-            # The blob storage does not NEED to delete orphans (for example for a NullBlobStorage)
-            pass
         else:
             logger.debug(
                 "🧹 DeleteOrphanBlobs[%s] Removed %d blobs.",

--- a/harp_apps/notifications/settings.py
+++ b/harp_apps/notifications/settings.py
@@ -4,6 +4,5 @@ from harp.config import Configurable, ApplicationSettingsMixin
 
 
 class NotificationsSettings(ApplicationSettingsMixin, Configurable):
-    enabled: bool = True
     slack_webhook_url: Optional[str] = None
     google_chat_webhook_url: Optional[str] = None

--- a/harp_apps/proxy/adapters.py
+++ b/harp_apps/proxy/adapters.py
@@ -1,4 +1,3 @@
-import logging
 import time
 from typing import Any, Dict, Optional
 from urllib.parse import urlparse
@@ -7,8 +6,6 @@ from httpx import AsyncClient, Request, Response
 
 from harp import __parsed_version__
 from harp.http import HttpRequest
-
-logger = logging.getLogger(__name__)
 
 
 class HttpClientProxyAdapter:

--- a/harp_apps/proxy/controllers.py
+++ b/harp_apps/proxy/controllers.py
@@ -208,8 +208,7 @@ class HttpProxyController(AbstractHttpProxyController):
 
         # Check if response came from cache by reading the X-Cache header
         # This header is set by the proxy adapter based on hishel extensions
-        x_cache_header = response.headers.get("X-Cache", "").upper()
-        is_response_from_cache = x_cache_header == "HIT"
+        is_response_from_cache = response.headers.get("X-Cache", "").upper() == "HIT"
 
         # If the remote URL is in CHECKING status and the response is successful, set it up
         if self.remote[base_url].status == CHECKING and 200 <= response.status_code < 400:

--- a/harp_apps/proxy/events.py
+++ b/harp_apps/proxy/events.py
@@ -3,6 +3,7 @@ from typing import Callable, Optional, Self
 from whistle import Event
 
 from harp import get_logger
+from harp.utils.types import typeof
 from harp.http import BaseHttpMessage, HttpError, HttpResponse
 from harp.http.requests import HttpRequest
 from harp.models import Transaction
@@ -46,9 +47,7 @@ class ProxyFilterEvent(Event):
 
     def set_response(self, response: HttpResponse):
         if response is not None and not isinstance(response, HttpResponse):
-            raise ValueError(
-                f"Response must be an instance of HttpResponse, got {response!r} ({type(response).__module__}.{type(response).__qualname__})."
-            )
+            raise ValueError(f"Response must be an instance of HttpResponse, got {response!r} ({typeof(response)}).")
         self.response = response
 
     def _get_rule_name(self) -> str | None:
@@ -93,7 +92,7 @@ class ProxyFilterEvent(Event):
 
         if not isinstance(mixed, HttpResponse):
             raise ValueError(
-                f"Response must be an instance of HttpResponse or a dict, got {mixed!r} ({type(mixed).__module__}.{type(mixed).__qualname__})."
+                f"Response must be an instance of HttpResponse or a dict, got {mixed!r} ({typeof(mixed)})."
             )
 
         self.set_response(mixed)

--- a/harp_apps/storage/services/sql.py
+++ b/harp_apps/storage/services/sql.py
@@ -363,10 +363,9 @@ class SqlStorage(IStorage):
         time_bucket: str = TimeBucket.DAY.value,
         start_datetime: Optional[datetime] = None,
     ) -> list[TransactionsGroupedByTimeBucket]:
-        if time_bucket not in [e.value for e in TimeBucket]:
-            raise ValueError(
-                f"Invalid time bucket: {time_bucket}. Must be one of {', '.join([e.value for e in TimeBucket])}."
-            )
+        time_bucket_values = [tb.value for tb in TimeBucket]
+        if time_bucket not in time_bucket_values:
+            raise ValueError(f"Invalid time bucket: {time_bucket}. Must be one of {', '.join(time_bucket_values)}.")
 
         c_started_at = SqlTransaction.started_at
         s_date = TruncDatetime(literal(time_bucket), c_started_at).label("tb")

--- a/harp_apps/storage/worker.py
+++ b/harp_apps/storage/worker.py
@@ -9,6 +9,7 @@ from whistle import IAsyncEventDispatcher
 from harp import get_logger
 from harp.http import get_serializer_for
 from harp.models import Blob
+from harp.models.transactions import encode_cache_flag
 from harp.utils.background import AsyncWorkerQueue
 from harp_apps.proxy.events import (
     EVENT_TRANSACTION_ENDED,
@@ -151,16 +152,13 @@ class StorageAsyncWorkerQueue(AsyncWorkerQueue):
             return
 
         transaction_id = event.transaction.id
-        # Extract cache status - it's now set based on X-Cache: HIT/MISS header
-        cached = event.transaction.extras.get("cached")
 
         transaction_data = {
             "finished_at": event.transaction.finished_at.astimezone(UTC),
             "elapsed": event.transaction.elapsed,
             "tpdex": event.transaction.tpdex,
             "x_status_class": event.transaction.extras.get("status_class"),
-            # Store as "true" string for cached responses, consistent with database expectations
-            "x_cached": "true" if cached else None,
+            "x_cached": encode_cache_flag(event.transaction.extras.get("cached")),
         }
 
         async def update_transaction():


### PR DESCRIPTION
## Context

Code simplification review for the 0.10 release cut (quality only: reuse, simplification, efficiency, clarity, altitude). No behaviour changes, no bug hunting. Kept in a separate PR, apart from feature work and the version bump, so the release diff stays readable.

## Scope

Two passes:

1. **The 0.9 → 0.10 delta** (done in this PR) — reviewed the 72 non-test Python files changed since 0.9.
2. **Whole codebase** — in progress; further commits will follow on this branch.

## Pass 1 changes (behaviour-preserving)

- Extract `encode_cache_flag()` in `harp.models.transactions` so the `x_cached` storage encoding lives in one place, used by both `Transaction.as_storable_dict` and the storage worker instead of being inlined in two modules.
- Drop the redundant `enabled` field from `NotificationsSettings` (already provided by `ApplicationSettingsMixin`).
- `resolve_dependencies`: compute per-app in-degree while building the graph; drop the dead zero-initialisation that was always overwritten before use.
- Remove dead code: the empty `TYPE_CHECKING` block in `http_client` settings and the unused `_ensure_datestring` helper in the `http_cache` adapter.
- Minor: inline a single-use temporary in the proxy controller, drop a redundant local in the cache adapter, correct `print_report`'s return annotation to `int`.

## Deliberately deferred (larger refactors / risk, out of scope for a release simplify)

- Replace the hand-rolled topological sort in `applications.py` with stdlib `graphlib` (ordering-semantics risk).
- Gather independent blob-store reads/writes concurrently on the cache path (efficiency; concurrency risk on the hot path).
- Deduplicate the config-source double read in the two-pass `build()` (touches the loader).
- Generalise the cross-app service override in `http_cache` (belongs to the underlying mechanism work).