### PR TITLE
fix(ci): exclude cookiecutter template from Dependabot pip scan (#844)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,13 @@ version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/"
+    # The generated project template ships a Jinja-templated pyproject.toml, which is not valid
+    # Python packaging metadata; exclude it so Dependabot does not fail to parse it.
+    exclude-paths:
+      - "harp/commandline/cookiecutters/**"
     schedule:
       interval: "daily"
   - package-ecosystem: "npm"
-    directory: "/frontend"
+    directory: "/harp_apps/dashboard/frontend"
     schedule:
       interval: "daily"


### PR DESCRIPTION
Fixes #844.

## Problem

The Dependabot pip **dependency-graph submission** fails on the release line: `.github/dependabot.yml` scans the pip ecosystem from `/`, and Dependabot recurses into the generated-project template `harp/commandline/cookiecutters/project/{{cookiecutter.__dir_name}}/pyproject.toml`. That file contains Jinja placeholders, so it is not valid packaging metadata and Dependabot reports "not parseable", turning the Dependency Graph check red (pre-existing, surfaced by the "green at all times" DoD).

## Fix

- Add `exclude-paths: ["harp/commandline/cookiecutters/**"]` to the pip ecosystem so Dependabot skips the template manifest (it is the only manifest under that directory).
- Correct the npm ecosystem `directory` from the non-existent `/frontend` to the real `harp_apps/dashboard/frontend` (where `package.json` lives).

## Notes

Config-only change. `dependabot.yml` validated as well-formed YAML; `exclude-paths` is the documented Dependabot option for ignoring manifests during scans. The dependency-graph submission re-runs on the 0.10 branch once merged.