### PR TITLE
docs(release): document the pre-release code review passes

### DIFF
--- a/docs/contribute/release/chores.rst
+++ b/docs/contribute/release/chores.rst
@@ -3,6 +3,31 @@ Chores
 
 Before a new version is released, it's usually a good idea to do some housekeeping.
 
+Code review passes
+::::::::::::::::::
+
+Before cutting a release, the codebase goes through a sequence of review passes so the
+release ships with known, deliberate trade-offs rather than surprises. Each pass lands its
+changes in a dedicated, release-scoped branch (kept separate from feature work and the
+version bump) so the release diff stays readable, and each pass is reviewed and accepted
+before the next one starts.
+
+#. **Simplification review** — quality only: reuse, simplification, efficiency and clarity.
+   Run it first on the delta since the previous release (while it is fresh), then across the
+   whole codebase. This pass is not a bug hunt; larger refactors it surfaces are recorded as
+   follow-ups instead of being forced into the release.
+
+#. **Comprehensive review** — a deeper, multi-dimensional pass over the whole codebase
+   (architecture, performance, testing, reliability, maintainability) to catch caveats the
+   simplification pass is not meant to find. Actionable, low-risk findings are fixed in the
+   release-scoped branch; anything larger or riskier is recorded as a follow-up.
+
+#. **Security review** — a final pass focused on security (input handling, authentication and
+   secrets, dependency and supply-chain surface, injection and SSRF vectors) run before the
+   cut.
+
+Keep this section up to date as the review process evolves.
+
 Python dependencies (uv)
 ::::::::::::::::::::::::
 


### PR DESCRIPTION
Documents the sequence of review passes run before cutting a release, in `docs/contribute/release/chores.rst`:

1. **Simplification review** — quality only (reuse, simplification, efficiency, clarity), delta-then-whole-codebase; not a bug hunt.
2. **Comprehensive review** — deeper multi-dimensional pass (architecture, performance, testing, reliability, maintainability) for caveats the simplification pass isn't meant to catch.
3. **Security review** — final security-focused pass before the cut.

Each pass lands in a dedicated release-scoped branch and is accepted before the next begins. Docs-only change.