### PR TITLE
fix(proxy): cancel healthcheck tasks on shutdown

### DIFF
--- a/harp_apps/proxy/__app__.py
+++ b/harp_apps/proxy/__app__.py
@@ -5,6 +5,7 @@ Proxy Application
 
 import asyncio
 from asyncio import TaskGroup
+from contextlib import suppress
 from typing import cast
 
 from harp.config import Application
@@ -71,12 +72,16 @@ async def on_bound(event: OnBoundEvent):
 
 
 async def on_shutdown(event: OnShutdownEvent):
-    await event.provider.get(PROXY_HEALTHCHECKS_TASK)._abort()
+    task = event.provider.get(PROXY_HEALTHCHECKS_TASK)
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
 
 
 application = Application(
     dependencies=["http_client"],
     on_bind=on_bind,
     on_bound=on_bound,
+    on_shutdown=on_shutdown,
     settings_type=ProxySettings,
 )

--- a/harp_apps/proxy/tests/test_app_lifecycle.py
+++ b/harp_apps/proxy/tests/test_app_lifecycle.py
@@ -1,0 +1,30 @@
+"""Lifecycle tests for the proxy application (shutdown of healthcheck background tasks)."""
+
+import asyncio
+
+from harp.config.events import OnShutdownEvent
+from harp_apps.proxy.__app__ import PROXY_HEALTHCHECKS_TASK, application, on_shutdown
+
+
+def test_application_registers_on_shutdown_handler():
+    # Regression: on_shutdown must be wired into the Application, otherwise the healthcheck
+    # background tasks are never cancelled and leak on every teardown.
+    assert application.on_shutdown is on_shutdown
+
+
+class _StubProvider:
+    def __init__(self, services):
+        self._services = services
+
+    def get(self, name):
+        return self._services[name]
+
+
+async def test_on_shutdown_cancels_the_healthchecks_task():
+    # The healthcheck task group runs forever; shutdown must cancel it cleanly (not crash).
+    task = asyncio.create_task(asyncio.sleep(3600))
+    event = OnShutdownEvent(None, _StubProvider({PROXY_HEALTHCHECKS_TASK: task}))
+
+    await on_shutdown(event)
+
+    assert task.cancelled()


### PR DESCRIPTION
Comprehensive-review finding (proxy teardown, 1A-H1 / T3a-H1).

## Problem
`on_bound` starts a background `TaskGroup` running each probe-enabled endpoint's `check_forever()` loop, stored under `PROXY_HEALTHCHECKS_TASK`. But:
- `on_shutdown` was **never wired** into `Application(...)`, so it never ran → the health-check tasks leaked on every teardown; and
- it called `Task._abort()`, which does not exist → `AttributeError` if it ever did run.

## Fix
- Wire `on_shutdown=on_shutdown` into the `Application`.
- Cancel the task group cleanly: `task.cancel()` + await with `CancelledError` suppressed.

## Tests
`harp_apps/proxy/tests/test_app_lifecycle.py`: a regression test that the handler is registered, and a behaviour test that shutdown cancels the task. Full proxy suite green, ruff clean.

_Changelog entry to be added by the release manager (changelog lane)._ Part of the 0.10 comprehensive-review fix set; sent incrementally.