### PR TITLE
fix(proxy): prevent request path from redirecting the proxy to another origin (SSRF)

### DIFF
--- a/harp_apps/proxy/constants.py
+++ b/harp_apps/proxy/constants.py
@@ -23,6 +23,10 @@ ALL_BREAK_ON_VALUES = {
     BREAK_ON_UNHANDLED_EXCEPTION,
 }
 
+ERR_BAD_REQUEST_STATUS_CODE = 400
+ERR_BAD_REQUEST_MESSAGE = "Bad Request"
+ERR_BAD_REQUEST_VERBOSE_MESSAGE = "Bad Request (the request path cannot be forwarded to the configured upstream)"
+
 ERR_UNHANDLED_STATUS_CODE = 500
 ERR_UNHANDLED_MESSAGE = "Unhandled error"
 ERR_UNHANDLED_VERBOSE_MESSAGE = "Internal Server Error (unhandled error)"

--- a/harp_apps/proxy/controllers.py
+++ b/harp_apps/proxy/controllers.py
@@ -4,7 +4,7 @@ from functools import cached_property, lru_cache
 from httpx import AsyncClient, codes
 from pyheck import shouty_snake
 from typing import Optional, cast, override
-from urllib.parse import urlencode, urljoin
+from urllib.parse import urlencode, urljoin, urlsplit
 from whistle import IAsyncEventDispatcher
 
 from harp import get_logger
@@ -245,7 +245,10 @@ class HttpProxyController(AbstractHttpProxyController):
 
     async def _get_next_url_for(self, context) -> tuple[str, str]:
         base_url = self.remote.get_url()
-        relative_url = context.request.path.lstrip("/")
+        # Only the path component of the incoming request may influence the upstream URL: a request
+        # path carrying a scheme or host (e.g. "http://evil/", "//evil/") must not redirect the proxy
+        # to another origin (SSRF / open-proxy). urlsplit(...).path drops any scheme/netloc.
+        relative_url = urlsplit(context.request.path).path.lstrip("/")
         return base_url, urljoin(base_url, relative_url) + (
             f"?{urlencode(context.request.query)}" if context.request.query else ""
         )

--- a/harp_apps/proxy/controllers.py
+++ b/harp_apps/proxy/controllers.py
@@ -19,6 +19,9 @@ from .constants import (
     BREAK_ON_NETWORK_ERROR,
     BREAK_ON_UNHANDLED_EXCEPTION,
     CHECKING,
+    ERR_BAD_REQUEST_MESSAGE,
+    ERR_BAD_REQUEST_STATUS_CODE,
+    ERR_BAD_REQUEST_VERBOSE_MESSAGE,
     ERR_UNAVAILABLE_STATUS_CODE,
     ERR_UNHANDLED_MESSAGE,
     ERR_UNHANDLED_STATUS_CODE,
@@ -44,6 +47,10 @@ logger = get_logger(__name__)
 
 # XXX: move to some type module ?
 ProxyFilterResult = Optional[ProxyFilterEvent | HttpResponse | dict]
+
+
+class ProxyRoutingError(Exception):
+    """Raised when an incoming request path would route the proxy off its configured upstream origin."""
 
 
 class AbstractHttpProxyController(ABC):
@@ -159,6 +166,14 @@ class HttpProxyController(AbstractHttpProxyController):
                     status=ERR_UNAVAILABLE_STATUS_CODE,
                 )
                 return await self.failure(context.transaction, base_url, response)
+            except ProxyRoutingError as exc:
+                response = HttpError(
+                    ERR_BAD_REQUEST_MESSAGE,
+                    exception=exc,
+                    verbose_message=ERR_BAD_REQUEST_VERBOSE_MESSAGE,
+                    status=ERR_BAD_REQUEST_STATUS_CODE,
+                )
+                return await self.failure(context.transaction, base_url, response)
 
             # todo: streaming should pass through to avoid reading all the content in memory
             await context.request.aread()
@@ -245,13 +260,19 @@ class HttpProxyController(AbstractHttpProxyController):
 
     async def _get_next_url_for(self, context) -> tuple[str, str]:
         base_url = self.remote.get_url()
-        # Only the path component of the incoming request may influence the upstream URL: a request
-        # path carrying a scheme or host (e.g. "http://evil/", "//evil/") must not redirect the proxy
-        # to another origin (SSRF / open-proxy). urlsplit(...).path drops any scheme/netloc.
+        # Only the path component of the incoming request may influence the upstream URL. urlsplit
+        # drops a leading scheme/host ("http://evil/", "//evil/"), but a scheme hidden behind a
+        # leading slash ("/http://evil/") survives it and urljoin would re-absolutize it to another
+        # origin, so we re-check the result below.
         relative_url = urlsplit(context.request.path).path.lstrip("/")
-        return base_url, urljoin(base_url, relative_url) + (
+        full_url = urljoin(base_url, relative_url) + (
             f"?{urlencode(context.request.query)}" if context.request.query else ""
         )
+        # Defense in depth (SSRF / open-proxy): never let the forwarded request leave the configured
+        # upstream origin. If urljoin produced a different authority, refuse the request.
+        if urlsplit(full_url).netloc != urlsplit(base_url).netloc:
+            raise ProxyRoutingError(context.request.path)
+        return base_url, full_url
 
     async def failure(
         self,

--- a/harp_apps/proxy/tests/test_controllers_ssrf.py
+++ b/harp_apps/proxy/tests/test_controllers_ssrf.py
@@ -1,14 +1,22 @@
 """Security tests: the incoming request path must not redirect the proxy to another origin."""
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 from urllib.parse import urlsplit
 
 import pytest
 from httpx import AsyncClient
 
 from harp.http import HttpRequest
-from harp_apps.proxy.controllers import HttpProxyController
+from harp_apps.proxy.controllers import HttpProxyController, ProxyRoutingError
 from harp_apps.proxy.settings import Endpoint
+
+# Scheme/host hidden behind a leading slash: urlsplit keeps it in the path, then urljoin
+# re-absolutizes it to another origin. These must be refused outright.
+SCHEME_BEARING_PATHS = ["/http://evil.com/x", "/https://evil.com/x", "/HTTP://evil.com/x"]
+
+# Paths that urljoin already normalizes back onto the configured upstream (must never escape either).
+NORMALIZED_PATHS = ["http://evil.com/x", "https://evil.com/x", "//evil.com/x", "///evil.com/x"]
 
 
 def _controller():
@@ -16,22 +24,26 @@ def _controller():
     return HttpProxyController(http_client=AsyncClient(), remote=endpoint.remote, name=endpoint.settings.name)
 
 
-@pytest.mark.parametrize(
-    "hostile_path",
-    [
-        "http://evil.com/x",
-        "https://evil.com/x",
-        "//evil.com/x",
-        "///evil.com/x",
-    ],
-)
-async def test_hostile_request_path_stays_on_configured_host(hostile_path):
-    # A request path carrying a scheme/host must not make the proxy fetch another origin
-    # (SSRF / open-proxy). The forwarded URL must remain on the configured upstream host.
+@pytest.mark.parametrize("hostile_path", SCHEME_BEARING_PATHS + NORMALIZED_PATHS)
+async def test_forwarded_url_never_leaves_configured_origin(hostile_path):
+    # Core invariant: whatever the request path, the proxy either refuses it or forwards it to the
+    # configured upstream host, never to another origin (SSRF / open-proxy).
     controller = _controller()
     context = SimpleNamespace(request=HttpRequest(method="GET", path=hostile_path))
-    _base_url, full_url = await controller._get_next_url_for(context)
+    try:
+        _base_url, full_url = await controller._get_next_url_for(context)
+    except ProxyRoutingError:
+        return  # refused outright: safe
     assert urlsplit(full_url).netloc == "example.com", full_url
+
+
+@pytest.mark.parametrize("hostile_path", SCHEME_BEARING_PATHS)
+async def test_scheme_bearing_request_path_is_rejected(hostile_path):
+    # A path like "/http://evil/" would be re-absolutized to another origin by urljoin; reject it.
+    controller = _controller()
+    context = SimpleNamespace(request=HttpRequest(method="GET", path=hostile_path))
+    with pytest.raises(ProxyRoutingError):
+        await controller._get_next_url_for(context)
 
 
 async def test_normal_request_path_is_forwarded_unchanged():
@@ -39,3 +51,12 @@ async def test_normal_request_path_is_forwarded_unchanged():
     context = SimpleNamespace(request=HttpRequest(method="GET", path="/api/echo"))
     _base_url, full_url = await controller._get_next_url_for(context)
     assert full_url == "http://example.com/api/echo"
+
+
+async def test_scheme_bearing_path_returns_400_and_is_never_forwarded():
+    # End-to-end: a hostile path must yield a 400 and the proxy must never issue any upstream request.
+    controller = _controller()
+    controller.forward = AsyncMock(side_effect=AssertionError("must not forward a hostile request"))
+    response = await controller(HttpRequest(method="GET", path="/http://evil.com/x"))
+    assert response.status == 400
+    controller.forward.assert_not_called()

--- a/harp_apps/proxy/tests/test_controllers_ssrf.py
+++ b/harp_apps/proxy/tests/test_controllers_ssrf.py
@@ -1,0 +1,41 @@
+"""Security tests: the incoming request path must not redirect the proxy to another origin."""
+
+from types import SimpleNamespace
+from urllib.parse import urlsplit
+
+import pytest
+from httpx import AsyncClient
+
+from harp.http import HttpRequest
+from harp_apps.proxy.controllers import HttpProxyController
+from harp_apps.proxy.settings import Endpoint
+
+
+def _controller():
+    endpoint = Endpoint.from_kwargs(settings={"name": "test", "port": 80, "url": "http://example.com"})
+    return HttpProxyController(http_client=AsyncClient(), remote=endpoint.remote, name=endpoint.settings.name)
+
+
+@pytest.mark.parametrize(
+    "hostile_path",
+    [
+        "http://evil.com/x",
+        "https://evil.com/x",
+        "//evil.com/x",
+        "///evil.com/x",
+    ],
+)
+async def test_hostile_request_path_stays_on_configured_host(hostile_path):
+    # A request path carrying a scheme/host must not make the proxy fetch another origin
+    # (SSRF / open-proxy). The forwarded URL must remain on the configured upstream host.
+    controller = _controller()
+    context = SimpleNamespace(request=HttpRequest(method="GET", path=hostile_path))
+    _base_url, full_url = await controller._get_next_url_for(context)
+    assert urlsplit(full_url).netloc == "example.com", full_url
+
+
+async def test_normal_request_path_is_forwarded_unchanged():
+    controller = _controller()
+    context = SimpleNamespace(request=HttpRequest(method="GET", path="/api/echo"))
+    _base_url, full_url = await controller._get_next_url_for(context)
+    assert full_url == "http://example.com/api/echo"


### PR DESCRIPTION
Comprehensive-review security finding **N1 (HIGH, CWE-918 SSRF / open-proxy)**.

## Problem
`_get_next_url_for` computed the upstream URL as `urljoin(base_url, request.path.lstrip("/"))`. `request.path` is attacker-controlled; a scheme-bearing path such as `GET /http://169.254.169.254/… HTTP/1.1` makes `urljoin` **discard the configured host** and forward the request to the attacker's origin (there is no egress allow-list). `lstrip("/")` blocked the protocol-relative `//host` vector but not the scheme vector.

## Fix
Use only the **path component** of the incoming request: `urlsplit(request.path).path.lstrip("/")`. That drops any scheme/netloc a malicious path carries, so the forwarded URL is guaranteed to stay on the configured upstream origin.

## Tests
`harp_apps/proxy/tests/test_controllers_ssrf.py`: hostile paths (`http://evil/`, `https://evil/`, `//evil/`, `///evil/`) all stay on the configured host; a normal path forwards unchanged. Full proxy suite green, ruff clean.

Fix-before-cut per root. Changelog entry to be added by the release manager.