### PR TITLE
fix(storage): bind a plain string for the MySQL full-text search parameter

### DIFF
--- a/harp_apps/storage/services/sql.py
+++ b/harp_apps/storage/services/sql.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime, timedelta
 from operator import itemgetter
 from typing import Iterable, Optional, override
 
-from sqlalchemy import and_, bindparam, case, delete, func, literal, literal_column, null, or_, select, text
+from sqlalchemy import and_, bindparam, case, delete, func, literal, null, or_, select, text
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
 from sqlalchemy.sql.functions import count
@@ -121,7 +121,7 @@ def _filter_transactions_based_on_text(query, search_text: str, dialect_name: st
                 f"AGAINST (:search_text IN BOOLEAN MODE) OR "
                 f"MATCH ({SqlMessage.__tablename__}.summary) "
                 f"AGAINST (:search_text IN BOOLEAN MODE)",
-            ).bindparams(bindparam("search_text", literal_column(f"'{search_text}*'")))
+            ).bindparams(bindparam("search_text", f"{search_text}*"))
         )
 
     return query.filter(

--- a/harp_apps/storage/tests/test_sql_text_search.py
+++ b/harp_apps/storage/tests/test_sql_text_search.py
@@ -1,0 +1,17 @@
+"""Regression test for the MySQL full-text-search filter parameter binding."""
+
+from sqlalchemy import select
+from sqlalchemy.dialects import mysql
+
+from harp_apps.storage.models import Transaction as SqlTransaction
+from harp_apps.storage.services.sql import _filter_transactions_based_on_text
+
+
+def test_mysql_full_text_search_binds_a_plain_string():
+    # The MySQL branch must bind ``search_text`` as a plain string ("<text>*" for boolean-mode
+    # prefix matching). Binding a ``literal_column`` (a column expression) instead is not a valid
+    # parameter value: it breaks MySQL full-text search at runtime and crashes literal-binds
+    # rendering. Compiling with literal_binds must succeed and inline the escaped string.
+    query = _filter_transactions_based_on_text(select(SqlTransaction), "foo", "mysql")
+    compiled = str(query.compile(dialect=mysql.dialect(), compile_kwargs={"literal_binds": True}))
+    assert "'foo*'" in compiled


### PR DESCRIPTION
Comprehensive-review finding **1A-H3 residue** (the SQLi lead was a false positive; this is the real correctness bug).

## Problem
The MySQL full-text branch bound `search_text` as a `literal_column(f"'{search_text}*'")` — a column *expression*, not a value. That is not a valid bound parameter: it breaks MySQL FTS at runtime (the driver receives a `ColumnClause`) and crashes literal-binds rendering (`CompileError`).

## Fix
Bind the plain boolean-mode string `f"{search_text}*"`, so the parameter is passed and escaped by the driver as intended. (The `FULLTEXT` indexes `endpoint_ft_index` / `summary_ft_index` are created for MySQL by the storage migrations, so the `MATCH … AGAINST` path is otherwise correct.)

## Tests
`harp_apps/storage/tests/test_sql_text_search.py`: a compile-based regression on the MySQL dialect that reproduces the exact `CompileError` before the fix and asserts the escaped `'foo*'` renders after. Runs everywhere (no live MySQL needed). ruff clean.

## Note on C3 (enable MySQL in CI)
Kept **separate** from this fix. `TEST_ALL_DATABASES=1` runs the *whole* storage suite on MySQL and may surface unrelated latent MySQL failures; enabling it belongs in its own PR where those can be triaged without blocking this correctness fix. (Local validation here was blocked by an environment disk/Docker constraint.)

Fix-before-cut per root. Changelog entry to be added by the release manager.