### PR TITLE
fix(config): parse !cfg comparison operands as literals, not code

### DIFF
--- a/harp/services/references.py
+++ b/harp/services/references.py
@@ -1,3 +1,4 @@
+import ast
 import operator
 from typing import Any, Self
 
@@ -131,7 +132,7 @@ class LazySettingReference(BaseReference):
                 break
 
         if operator and other_operand:
-            other_operand = eval(other_operand.strip())
+            other_operand = ast.literal_eval(other_operand.strip())
             if operator in operators:
                 return operators[operator](x, other_operand) or None
             else:

--- a/harp/services/tests/test_references.py
+++ b/harp/services/tests/test_references.py
@@ -1,3 +1,5 @@
+import pytest
+
 from harp.services.models import _resolve
 from harp.services.references import LazySettingReference
 
@@ -11,6 +13,13 @@ def test_equality_cfgref():
     ref = LazySettingReference("foo.bar == 'baz'")
     assert ref.resolve({"foo": {"bar": "baz"}}) is True
     assert ref.resolve({"foo": {"bar": "boo"}}) is None
+
+
+def test_cfgref_operand_must_be_a_literal():
+    # The right-hand operand is parsed as a Python literal, never executed as code.
+    ref = LazySettingReference("foo.bar == __import__('os').getcwd()")
+    with pytest.raises(ValueError):
+        ref.resolve({"foo": {"bar": "baz"}})
 
 
 def test_resolve_dict_with_references():


### PR DESCRIPTION
Comprehensive-review finding **1B-M6** (config hardening).

## Problem
`LazySettingReference.resolve` used `eval()` on the right-hand operand of a `!cfg` comparison (e.g. `!cfg "storage.type == 'sql'"`), executing arbitrary Python from the config expression.

## Fix
Operands are always Python literals (`'sql'`, `None`, …). Parse them with `ast.literal_eval`, which rejects non-literal input instead of executing it. Trusted-config only (author-time), so this is defense-in-depth, not a remote vuln.

## Tests
`harp/services/tests/test_references.py`: a new test that a non-literal operand (`__import__('os').getcwd()`) raises instead of executing; existing equality tests still pass.

Fix-before-cut per root. Changelog entry to be added by the release manager.