### PR TITLE
fix(http_cache): write and read the cache created_at field as UTC

### DIFF
--- a/harp_apps/http_cache/adapters.py
+++ b/harp_apps/http_cache/adapters.py
@@ -1,7 +1,7 @@
 import typing as tp
 import uuid
 import yaml
-from datetime import datetime
+from datetime import UTC, datetime
 from hishel import Entry, EntryMeta, Request, Response
 from hishel._core.models import AnyIterable
 
@@ -17,6 +17,21 @@ from harp_apps.storage.types import IBlobStorage
 # Migrated from hishel._serializers to avoid dependency on removed internal module
 KNOWN_REQUEST_EXTENSIONS = ("timeout", "sni_hostname")
 KNOWN_RESPONSE_EXTENSIONS = ("http_version", "reason_phrase")
+
+# RFC 1123 wire format used for the backward-compatible `created_at` cache field. It is always UTC
+# (the trailing "GMT" is literal), so it must be written and read as UTC regardless of the host
+# timezone, otherwise the stored value is mislabeled and round-trips break across timezones.
+_CREATED_AT_GMT_FORMAT = "%a, %d %b %Y %H:%M:%S GMT"
+
+
+def _format_created_at(timestamp: float) -> str:
+    """Render a POSIX timestamp as an RFC 1123 GMT string."""
+    return datetime.fromtimestamp(timestamp, UTC).strftime(_CREATED_AT_GMT_FORMAT)
+
+
+def _parse_created_at(value: str) -> float:
+    """Parse an RFC 1123 GMT string back to a POSIX timestamp."""
+    return datetime.strptime(value, _CREATED_AT_GMT_FORMAT).replace(tzinfo=UTC).timestamp()
 
 
 class SerializedRequest(tp.TypedDict):
@@ -90,11 +105,7 @@ class AsyncStorageAdapter:
         meta = EntryMeta(
             created_at=meta_data.get(
                 "created_at_ts",
-                (
-                    datetime.strptime(meta_data["created_at"], "%a, %d %b %Y %H:%M:%S GMT").timestamp()
-                    if "created_at" in meta_data
-                    else 0.0
-                ),
+                (_parse_created_at(meta_data["created_at"]) if "created_at" in meta_data else 0.0),
             ),
             deleted_at=meta_data.get("deleted_at"),
         )
@@ -136,7 +147,7 @@ class AsyncStorageAdapter:
         This maintains the existing YAML format with added fields for hishel 1.0.
         """
         # Store both timestamp (new format) and formatted string (backward compat)
-        created_at_dt = datetime.fromtimestamp(meta.created_at)
+        created_at_gmt = _format_created_at(meta.created_at)
 
         return await self.storage.force_put(
             Blob(
@@ -148,7 +159,7 @@ class AsyncStorageAdapter:
                         "response": response,
                         "metadata": {
                             "cache_key": key,
-                            "created_at": created_at_dt.strftime("%a, %d %b %Y %H:%M:%S GMT"),  # Backward compat
+                            "created_at": created_at_gmt,  # Backward compat
                             "created_at_ts": meta.created_at,  # New format
                             "deleted_at": meta.deleted_at,
                             "number_of_uses": extra.get("number_of_uses", 0),  # Backward compat

--- a/harp_apps/http_cache/tests/test_adapters_created_at.py
+++ b/harp_apps/http_cache/tests/test_adapters_created_at.py
@@ -1,0 +1,48 @@
+"""The cache `created_at` field is written and read as GMT/UTC, independent of the host timezone."""
+
+import os
+import time
+from contextlib import contextmanager
+
+from harp_apps.http_cache.adapters import _format_created_at, _parse_created_at
+
+
+@contextmanager
+def _local_timezone(tz: str):
+    old_tz = os.environ.get("TZ")
+    os.environ["TZ"] = tz
+    time.tzset()
+    try:
+        yield
+    finally:
+        if old_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = old_tz
+        time.tzset()
+
+
+# 2023-11-14 22:13:20 UTC
+_TS = 1_700_000_000.0
+_GMT = "Tue, 14 Nov 2023 22:13:20 GMT"
+
+
+def test_format_created_at_renders_utc():
+    assert _format_created_at(_TS) == _GMT
+
+
+def test_parse_created_at_reads_gmt_as_utc():
+    assert _parse_created_at(_GMT) == _TS
+
+
+def test_created_at_roundtrip_is_stable():
+    assert _parse_created_at(_format_created_at(_TS)) == _TS
+
+
+def test_created_at_is_utc_regardless_of_local_timezone():
+    # The GMT string is a wire format: a non-UTC server must still write and read it as UTC,
+    # otherwise the stored value is mislabeled and round-trips break across timezones.
+    with _local_timezone("America/New_York"):
+        assert _format_created_at(_TS) == _GMT
+        assert _parse_created_at(_GMT) == _TS
+        assert _parse_created_at(_format_created_at(_TS)) == _TS


### PR DESCRIPTION
## What

The backward-compatible `created_at` field in cache metadata is an RFC 1123 GMT string. It was:

- **written** from a naive *local* datetime (`datetime.fromtimestamp(ts)`) then labelled `GMT`, and
- **read** back with `strptime(...).timestamp()`, which reinterprets the naive value as *local*.

On a UTC host the two errors cancel, but on any non-UTC host the stored string is mislabelled (local wall-clock tagged GMT) and cross-timezone round-trips are wrong. The `created_at` string is also a fallback path (the newer `created_at_ts` numeric field is preferred on read), so this only bites legacy-format entries, but it is a latent correctness bug.

## Fix

Render and parse the field as UTC on both sides. The GMT wire format (previously duplicated in two places) is extracted to a single constant with two small helpers, `_format_created_at` / `_parse_created_at`.

## Tests

`test_adapters_created_at.py`: round-trip stability plus a timezone-independence test that forces a non-UTC `TZ` and asserts the value is still written and read as UTC. No behaviour change on a UTC host.