### PR TITLE
fix(dashboard): retain the create-users background task

### DIFF
--- a/harp_apps/dashboard/controllers/__init__.py
+++ b/harp_apps/dashboard/controllers/__init__.py
@@ -30,6 +30,7 @@ class DashboardController(RoutingController):
 
     _ui_static_middleware = None
     _ui_devserver_proxy_controller = None
+    _create_users_task = None
 
     #: Static directory to look for pre-built assets.
     static_build_path = os.path.realpath(os.path.join(os.path.dirname(os.path.abspath(dashboard.__file__)), "web"))
@@ -48,9 +49,12 @@ class DashboardController(RoutingController):
         self.storage = storage
         self.settings = settings
 
-        # create users if they don't exist
+        # create users if they don't exist; keep a strong reference to the task, as the event loop
+        # only holds a weak one and would let it be garbage-collected before completion.
         if isinstance(self.settings.auth, BasicAuthSettings):
-            asyncio.create_task(self.storage.create_users_once_ready(self.settings.auth.users))
+            self._create_users_task = asyncio.create_task(
+                self.storage.create_users_once_ready(self.settings.auth.users)
+            )
 
         # UI is always initialized when the dashboard app is enabled
         # (the `enabled` setting controls whether the entire app loads)

--- a/harp_apps/dashboard/tests/controllers/test_authentication.py
+++ b/harp_apps/dashboard/tests/controllers/test_authentication.py
@@ -1,3 +1,4 @@
+import asyncio
 from base64 import b64encode
 from typing import cast
 from unittest.mock import AsyncMock, Mock
@@ -47,6 +48,22 @@ async def test_controller_auth_plaintext():
     # wrong password
     response = await controller(HttpRequest(headers=_get_auth_headers("admin", "wrong")), AsyncMock())
     assert response.status == 401
+
+
+async def test_create_users_task_is_retained():
+    # asyncio.create_task keeps only a weak reference to the task, so the controller must hold a
+    # strong reference itself, otherwise the user-creation task can be garbage-collected mid-flight.
+    controller = await _create_mock_controller(
+        settings=DashboardSettings(
+            auth=BasicAuthSettings(
+                type="basic",
+                algorithm="plaintext",
+                users={"admin": User(password="admin")},
+            ),
+            devserver={"enabled": True, "port": 5173},
+        )
+    )
+    assert isinstance(controller._create_users_task, asyncio.Task)
 
 
 async def _create_mock_controller(settings: DashboardSettings = None):


### PR DESCRIPTION
## What

`DashboardController.__init__` fires the initial user creation with `asyncio.create_task(...)` but discards the returned task. The event loop keeps only a **weak** reference to a task, so an unreferenced one can be garbage-collected before it finishes, silently dropping the user creation (and any exception it raises).

## Fix

Keep a strong reference on the controller (`self._create_users_task`) for the controller's lifetime, per the [asyncio.create_task](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task) guidance.

## Tests

`test_create_users_task_is_retained` asserts the controller holds the task after construction.