### PR TITLE
perf: hot-path optimizations from the comprehensive review

### DIFF
--- a/harp/asgi/kernel.py
+++ b/harp/asgi/kernel.py
@@ -1,4 +1,5 @@
 import traceback
+from functools import lru_cache
 from inspect import signature
 
 from asgiref.typing import ASGIReceiveCallable, ASGISendCallable, Scope
@@ -24,6 +25,13 @@ from .events import (
 )
 
 logger = get_logger(__name__)
+
+
+@lru_cache(maxsize=1024)
+def _cached_signature(subject):
+    """Memoize signature introspection: controllers are long-lived, so their prototype never
+    changes, and this runs on every request."""
+    return signature(subject)
 
 
 class ASGIKernel:
@@ -80,7 +88,7 @@ class ASGIKernel:
         try:
             return [
                 (candidates[name] if name in candidates or param.default is param.empty else param.default)
-                for name, param in signature(subject).parameters.items()
+                for name, param in _cached_signature(subject).parameters.items()
                 if param.kind is not param.KEYWORD_ONLY
             ], {}
         except KeyError as exc:

--- a/harp/asgi/tests/test_kernel_resolve_arguments.py
+++ b/harp/asgi/tests/test_kernel_resolve_arguments.py
@@ -1,0 +1,37 @@
+import inspect
+
+from harp.asgi import kernel
+from harp.asgi.kernel import ASGIKernel
+
+
+def test_resolve_arguments_uses_candidates_and_defaults():
+    k = ASGIKernel()
+
+    def subject(a, b=2, c=3): ...
+
+    args, kwargs = k._resolve_arguments(subject, a=1, c=9)
+    assert args == [1, 2, 9]
+    assert kwargs == {}
+
+
+def test_signature_is_memoized_per_subject(monkeypatch):
+    # signature() runs on every request; controllers are stable, so it must be computed once per
+    # subject and reused, not recomputed on each call.
+    kernel._cached_signature.cache_clear()
+    calls = {"n": 0}
+    real_signature = inspect.signature
+
+    def counting_signature(subject):
+        calls["n"] += 1
+        return real_signature(subject)
+
+    monkeypatch.setattr(kernel, "signature", counting_signature)
+
+    def subject(a, b=2): ...
+
+    k = ASGIKernel()
+    first, _ = k._resolve_arguments(subject, a=1, b=5)
+    second, _ = k._resolve_arguments(subject, a=1, b=5)
+
+    assert first == second == [1, 5]
+    assert calls["n"] == 1

--- a/harp_apps/storage/services/blob_storages/sql.py
+++ b/harp_apps/storage/services/blob_storages/sql.py
@@ -94,6 +94,8 @@ class SqlBlobStorage(IBlobStorage):
                     await conn.commit()
                 except IntegrityError:
                     pass  # already there? that's fine!
+        # the blob is now known to be stored: remember it so later puts skip the existence query.
+        self.seen.add(blob.id)
         return blob
 
     @override
@@ -138,7 +140,7 @@ class SqlBlobStorage(IBlobStorage):
             return True
 
         async with self.engine.connect() as conn:
-            return bool(
+            found = bool(
                 (
                     await conn.execute(
                         select(
@@ -147,3 +149,7 @@ class SqlBlobStorage(IBlobStorage):
                     )
                 ).scalar_one()
             )
+        if found:
+            # remember it so later exists()/put() calls skip the existence query.
+            self.seen.add(blob_id)
+        return found

--- a/harp_apps/storage/services/sql.py
+++ b/harp_apps/storage/services/sql.py
@@ -328,12 +328,12 @@ class SqlStorage(IStorage):
                 query.with_only_columns(func.count(SqlTransaction.id)).order_by(None)
             )
 
-        # apply limit/offset (after count)
-        query = query.limit(PAGE_SIZE)
-        if page:
-            query = query.offset(max(0, (page - 1) * PAGE_SIZE))
+            # apply limit/offset (after count), then read the page in the same session so count and
+            # list share one transaction (one round-trip setup, consistent snapshot).
+            query = query.limit(PAGE_SIZE)
+            if page:
+                query = query.offset(max(0, (page - 1) * PAGE_SIZE))
 
-        async with self.begin() as session:
             for transaction in (await session.scalars(query)).unique().all():
                 result.append(transaction.to_model(with_user_flags=True))
 

--- a/harp_apps/storage/tests/test_services_blob_storages_sql.py
+++ b/harp_apps/storage/tests/test_services_blob_storages_sql.py
@@ -30,3 +30,22 @@ async def test_basics(sql_blob_storage: SqlBlobStorage):
     assert await _storage.get("foo") is None
     async with _storage.engine.connect() as conn:
         assert (await conn.execute(text("SELECT * FROM blobs WHERE id = 'foo'"))).fetchone() is None
+
+
+async def test_put_populates_seen_cache(sql_blob_storage: SqlBlobStorage):
+    # After a put, the blob id is known to be stored, so it must be cached to let later puts skip
+    # the existence query.
+    storage = sql_blob_storage
+    assert not storage.seen.exists("foo")
+    await storage.put(Blob(id="foo", data=b"bar", content_type="text/plain"))
+    assert storage.seen.exists("foo")
+
+
+async def test_exists_populates_seen_cache(sql_blob_storage: SqlBlobStorage):
+    # A positive existence check must also seed the cache. force_put does not touch the cache, so it
+    # gives us a stored-but-uncached blob.
+    storage = sql_blob_storage
+    await storage.force_put(Blob(id="foo", data=b"bar", content_type="text/plain"))
+    assert not storage.seen.exists("foo")
+    assert await storage.exists("foo")
+    assert storage.seen.exists("foo")

--- a/harp_apps/storage/tests/test_storage_transactions.py
+++ b/harp_apps/storage/tests/test_storage_transactions.py
@@ -3,6 +3,27 @@ from harp_apps.storage.utils.testing.mixins import StorageTestFixtureMixin
 
 
 class TestStorageTransactions(StorageTestFixtureMixin):
+    async def test_get_transaction_list_uses_a_single_session(self, sql_storage: SqlStorage):
+        t1 = await self.create_transaction(sql_storage, endpoint="foo")
+        t2 = await self.create_transaction(sql_storage, endpoint="bar")
+        for t in (t1, t2):
+            await self.create_message(sql_storage, transaction_id=t.id, kind="misc", summary="s", headers="h", body="b")
+
+        calls = {"n": 0}
+        original_begin = sql_storage.begin
+
+        def counting_begin(*args, **kwargs):
+            calls["n"] += 1
+            return original_begin(*args, **kwargs)
+
+        sql_storage.begin = counting_begin
+        result = await sql_storage.get_transaction_list(username="anonymous", with_messages=True)
+
+        # the count and the page are read in a single session/transaction
+        assert calls["n"] == 1
+        assert result.meta["total"] == 2
+        assert len(result) == 2
+
     async def test_get_transaction_list_with_tags(self, sql_storage: SqlStorage):
         t1 = await self.create_transaction(sql_storage, endpoint="foo")
 


### PR DESCRIPTION
Three independent, low-risk performance fixes from the comprehensive review. One commit each.

## 1. `perf(asgi)`: memoize controller signature resolution
`ASGIKernel._resolve_arguments` called `inspect.signature(subject)` on **every request**, though controllers are long-lived and their prototype never changes. Cached per subject (bounded LRU).

## 2. `perf(storage)`: populate the blob seen-cache after put/exists
`SqlBlobStorage` keeps a `seen` LRU to short-circuit `put()`/`exists()`, but it was never populated on the write path, so every `put()` of an already-stored blob still paid an existence `SELECT`. Seed the cache once the blob is known to be stored. (A proxy stores the same header/body blobs repeatedly, so this is a common path.)

## 3. `perf(storage)`: single session for `get_transaction_list`
The total-count query and the page query ran in two separate sessions/transactions. Merged into one: fewer round-trips and a consistent snapshot between the count and the listed rows.

## Tests
- `test_kernel_resolve_arguments.py`: signature computed once per subject; resolution unchanged.
- `test_services_blob_storages_sql.py`: `put`/`exists` seed the seen-cache.
- `test_storage_transactions.py`: `get_transaction_list` opens exactly one session; total/rows correct.

No behaviour change; validated on sqlite + postgres.