### PR TITLE
perf(asgi): memoize controller signature resolution

### DIFF
--- a/harp/asgi/kernel.py
+++ b/harp/asgi/kernel.py
@@ -1,4 +1,5 @@
 import traceback
+from functools import lru_cache
 from inspect import signature
 
 from asgiref.typing import ASGIReceiveCallable, ASGISendCallable, Scope
@@ -24,6 +25,13 @@ from .events import (
 )
 
 logger = get_logger(__name__)
+
+
+@lru_cache(maxsize=1024)
+def _cached_signature(subject):
+    """Memoize signature introspection: controllers are long-lived, so their prototype never
+    changes, and this runs on every request."""
+    return signature(subject)
 
 
 class ASGIKernel:
@@ -80,7 +88,7 @@ class ASGIKernel:
         try:
             return [
                 (candidates[name] if name in candidates or param.default is param.empty else param.default)
-                for name, param in signature(subject).parameters.items()
+                for name, param in _cached_signature(subject).parameters.items()
                 if param.kind is not param.KEYWORD_ONLY
             ], {}
         except KeyError as exc:

--- a/harp/asgi/tests/test_kernel_resolve_arguments.py
+++ b/harp/asgi/tests/test_kernel_resolve_arguments.py
@@ -1,0 +1,37 @@
+import inspect
+
+from harp.asgi import kernel
+from harp.asgi.kernel import ASGIKernel
+
+
+def test_resolve_arguments_uses_candidates_and_defaults():
+    k = ASGIKernel()
+
+    def subject(a, b=2, c=3): ...
+
+    args, kwargs = k._resolve_arguments(subject, a=1, c=9)
+    assert args == [1, 2, 9]
+    assert kwargs == {}
+
+
+def test_signature_is_memoized_per_subject(monkeypatch):
+    # signature() runs on every request; controllers are stable, so it must be computed once per
+    # subject and reused, not recomputed on each call.
+    kernel._cached_signature.cache_clear()
+    calls = {"n": 0}
+    real_signature = inspect.signature
+
+    def counting_signature(subject):
+        calls["n"] += 1
+        return real_signature(subject)
+
+    monkeypatch.setattr(kernel, "signature", counting_signature)
+
+    def subject(a, b=2): ...
+
+    k = ASGIKernel()
+    first, _ = k._resolve_arguments(subject, a=1, b=5)
+    second, _ = k._resolve_arguments(subject, a=1, b=5)
+
+    assert first == second == [1, 5]
+    assert calls["n"] == 1


### PR DESCRIPTION
From the comprehensive review (split out of the perf set into one focused PR).

`ASGIKernel._resolve_arguments` called `inspect.signature(subject)` on **every request**, though controllers are long-lived and their prototype never changes. Cache it per subject with a bounded LRU.

**Correctness:** pure memoization on a stable key; no result changes.

**Test:** `test_kernel_resolve_arguments.py` asserts the signature is computed once per subject and that argument resolution is unchanged.