### PR TITLE
perf(storage): populate the blob seen-cache after put and exists

### DIFF
--- a/harp_apps/storage/services/blob_storages/sql.py
+++ b/harp_apps/storage/services/blob_storages/sql.py
@@ -94,6 +94,8 @@ class SqlBlobStorage(IBlobStorage):
                     await conn.commit()
                 except IntegrityError:
                     pass  # already there? that's fine!
+        # the blob is now known to be stored: remember it so later puts skip the existence query.
+        self.seen.add(blob.id)
         return blob
 
     @override
@@ -138,7 +140,7 @@ class SqlBlobStorage(IBlobStorage):
             return True
 
         async with self.engine.connect() as conn:
-            return bool(
+            found = bool(
                 (
                     await conn.execute(
                         select(
@@ -147,3 +149,7 @@ class SqlBlobStorage(IBlobStorage):
                     )
                 ).scalar_one()
             )
+        if found:
+            # remember it so later exists()/put() calls skip the existence query.
+            self.seen.add(blob_id)
+        return found

--- a/harp_apps/storage/tests/test_services_blob_storages_sql.py
+++ b/harp_apps/storage/tests/test_services_blob_storages_sql.py
@@ -30,3 +30,22 @@ async def test_basics(sql_blob_storage: SqlBlobStorage):
     assert await _storage.get("foo") is None
     async with _storage.engine.connect() as conn:
         assert (await conn.execute(text("SELECT * FROM blobs WHERE id = 'foo'"))).fetchone() is None
+
+
+async def test_put_populates_seen_cache(sql_blob_storage: SqlBlobStorage):
+    # After a put, the blob id is known to be stored, so it must be cached to let later puts skip
+    # the existence query.
+    storage = sql_blob_storage
+    assert not storage.seen.exists("foo")
+    await storage.put(Blob(id="foo", data=b"bar", content_type="text/plain"))
+    assert storage.seen.exists("foo")
+
+
+async def test_exists_populates_seen_cache(sql_blob_storage: SqlBlobStorage):
+    # A positive existence check must also seed the cache. force_put does not touch the cache, so it
+    # gives us a stored-but-uncached blob.
+    storage = sql_blob_storage
+    await storage.force_put(Blob(id="foo", data=b"bar", content_type="text/plain"))
+    assert not storage.seen.exists("foo")
+    assert await storage.exists("foo")
+    assert storage.seen.exists("foo")


### PR DESCRIPTION
From the comprehensive review (split out of the perf set into one focused PR).

`SqlBlobStorage` keeps a `seen` LRU to short-circuit `put()`/`exists()`, but it was never populated on the write path, so every `put()` of an already-stored blob still paid an existence `SELECT`. A proxy stores the same header/body blobs repeatedly, so this is a common path. Seed the cache once the blob is known to be stored.

**Correctness note:** `seen` is a positive cache ("this id is in the DB") consistent with the existing short-circuit; `delete()` already evicts. Ids are content-addressed (sha1), so a cached id staying valid matches the existing design. No new staleness window beyond what `put`/`exists` already assumed.

**Tests:** `put` and a positive `exists` both seed the cache.