### PR TITLE
perf(storage): read count and page in one session for get_transaction_list

### DIFF
--- a/harp_apps/storage/services/sql.py
+++ b/harp_apps/storage/services/sql.py
@@ -328,12 +328,12 @@ class SqlStorage(IStorage):
                 query.with_only_columns(func.count(SqlTransaction.id)).order_by(None)
             )
 
-        # apply limit/offset (after count)
-        query = query.limit(PAGE_SIZE)
-        if page:
-            query = query.offset(max(0, (page - 1) * PAGE_SIZE))
+            # apply limit/offset (after count), then read the page in the same session so count and
+            # list share one transaction (one round-trip setup, consistent snapshot).
+            query = query.limit(PAGE_SIZE)
+            if page:
+                query = query.offset(max(0, (page - 1) * PAGE_SIZE))
 
-        async with self.begin() as session:
             for transaction in (await session.scalars(query)).unique().all():
                 result.append(transaction.to_model(with_user_flags=True))
 

--- a/harp_apps/storage/tests/test_storage_transactions.py
+++ b/harp_apps/storage/tests/test_storage_transactions.py
@@ -3,6 +3,27 @@ from harp_apps.storage.utils.testing.mixins import StorageTestFixtureMixin
 
 
 class TestStorageTransactions(StorageTestFixtureMixin):
+    async def test_get_transaction_list_uses_a_single_session(self, sql_storage: SqlStorage):
+        t1 = await self.create_transaction(sql_storage, endpoint="foo")
+        t2 = await self.create_transaction(sql_storage, endpoint="bar")
+        for t in (t1, t2):
+            await self.create_message(sql_storage, transaction_id=t.id, kind="misc", summary="s", headers="h", body="b")
+
+        calls = {"n": 0}
+        original_begin = sql_storage.begin
+
+        def counting_begin(*args, **kwargs):
+            calls["n"] += 1
+            return original_begin(*args, **kwargs)
+
+        sql_storage.begin = counting_begin
+        result = await sql_storage.get_transaction_list(username="anonymous", with_messages=True)
+
+        # the count and the page are read in a single session/transaction
+        assert calls["n"] == 1
+        assert result.meta["total"] == 2
+        assert len(result) == 2
+
     async def test_get_transaction_list_with_tags(self, sql_storage: SqlStorage):
         t1 = await self.create_transaction(sql_storage, endpoint="foo")
 


### PR DESCRIPTION
From the comprehensive review (split out of the perf set into one focused PR — this is the correctness-touching one, kept isolated).

The total-count query and the page query ran in two separate sessions/transactions. Merge them into one session: fewer round-trips and, notably, a **consistent snapshot** between the count and the listed rows (previously a concurrent write between the two transactions could make `total` disagree with the returned page).

**Correctness:** both are read-only SELECTs; limit/offset are still applied only after the count. Behaviour is preserved and made more consistent.

**Test:** `get_transaction_list` now opens exactly one session (spy asserts a single `begin()`), with correct total and rows.