### PR TITLE
fix(ci): move the docker `latest` tag to every mainline release (C2)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -491,10 +491,9 @@ jobs:
             TAGS="ghcr.io/${{ github.repository }}:$VERSION,makersquad/harp-proxy:$VERSION"
             TAGS="$TAGS,ghcr.io/${{ github.repository }}:$MINOR,makersquad/harp-proxy:$MINOR"
             TAGS="$TAGS,ghcr.io/${{ github.repository }}:$MAJOR,makersquad/harp-proxy:$MAJOR"
-            # Only add latest tag for version 0.9.x releases
-            if echo "$VERSION" | grep -qE '^0\.9\.[0-9]+$'; then
-              TAGS="$TAGS,makersquad/harp-proxy:latest"
-            fi
+            # `latest` tracks the most recent mainline stable release (pre-releases are excluded by
+            # the branch above). Previously pinned to 0.9.x, which would have frozen `latest` at 0.9.
+            TAGS="$TAGS,makersquad/harp-proxy:latest"
             echo "Docker tags (mainline): $TAGS"
           else
             # Pre-release (e.g., 0.9.0-rc1) - only exact tag


### PR DESCRIPTION
## Problem (release blocker)

The release workflow pinned the `latest` Docker tag to `0.9.x` only:

```bash
# Only add latest tag for version 0.9.x releases
if echo "$VERSION" | grep -qE '^0\.9\.[0-9]+$'; then
  TAGS="$TAGS,makersquad/harp-proxy:latest"
fi
```

So cutting **0.10** (and every future release) would leave `makersquad/harp-proxy:latest` frozen on 0.9.

## Fix

`latest` now tracks any mainline **stable** release (pre-releases are already routed to the other branch and stay excluded).

Tag computation verified for representative versions:

| version | `latest`? |
|---|---|
| 0.9.5 | yes |
| 0.10.0 | yes |
| 0.10.3 | yes |
| 1.0.0 | yes |
| 0.11.0 | yes |
| 0.10.0-rc1 | no (pre-release) |

## Policy note for the release manager

This makes `latest` = *most recent mainline release cut*. If instead you want `latest` = *highest version ever* (so a late 0.9.x backport released after 0.10 would not move `latest` backward), say so and I'll switch to a version-comparison guard. For the normal in-order release flow the two are equivalent.