### PR TITLE
docs(develop): document `make dev` auto-reload task for projects

### DIFF
--- a/docs/develop/run.rst
+++ b/docs/develop/run.rst
@@ -40,6 +40,14 @@ If you've created a project using ``harp-proxy create project``, use the generat
     cd your-project
     make start
 
+While developing, use ``make dev`` instead: it runs the same server with auto-reload, restarting it
+whenever you change a file.
+
+.. code:: shell
+
+    cd your-project
+    make dev
+
 Or run directly with UV:
 
 .. code:: shell


### PR DESCRIPTION
The generated project `Makefile` provides a `make dev` target (auto-reload dev server, added in #823) next to `make start`, but the run guide only documented `make start`. Add a short note in the "With a project" section.